### PR TITLE
:sparkles: [FEATURE] 동아리 검색 API 구현 

### DIFF
--- a/src/main/java/kr/hanjari/backend/domain/enums/SortBy.java
+++ b/src/main/java/kr/hanjari/backend/domain/enums/SortBy.java
@@ -1,7 +1,19 @@
 package kr.hanjari.backend.domain.enums;
 
-public enum SortBy {
+import lombok.Getter;
+import org.springframework.data.domain.Sort;
 
-    // 가나다, 카테고리, 모집기준
-    NAME_ASC, CATEGORY_ASC, RECRUITMENT_STATUS_ASC,
+@Getter
+public enum SortBy {
+    NAME_ASC(Sort.by(Sort.Direction.ASC, "name")),
+    NAME_DESC(Sort.by(Sort.Direction.DESC, "name")),
+    RECRUITMENT_STATUS_ASC(Sort.by(Sort.Direction.ASC, "recruitmentStatus")
+            .and(Sort.by(Sort.Direction.ASC, "name"))); // 같은 상태에서는 name 기준 오름차순 정렬
+
+    private final Sort sort;
+
+    SortBy(Sort sort) {
+        this.sort = sort;
+    }
+
 }

--- a/src/main/java/kr/hanjari/backend/domain/enums/SortBy.java
+++ b/src/main/java/kr/hanjari/backend/domain/enums/SortBy.java
@@ -2,13 +2,13 @@ package kr.hanjari.backend.domain.enums;
 
 import lombok.Getter;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 
 @Getter
 public enum SortBy {
     NAME_ASC(Sort.by(Sort.Direction.ASC, "name")),
-    NAME_DESC(Sort.by(Sort.Direction.DESC, "name")),
-    RECRUITMENT_STATUS_ASC(Sort.by(Sort.Direction.ASC, "recruitmentStatus")
-            .and(Sort.by(Sort.Direction.ASC, "name"))); // 같은 상태에서는 name 기준 오름차순 정렬
+    CATEGORY_ASC(Sort.by(Direction.ASC, "category")),
+    RECRUITMENT_STATUS_ASC(Sort.by(Sort.Direction.ASC, "recruitmentStatus"));
 
     private final Sort sort;
 

--- a/src/main/java/kr/hanjari/backend/repository/ClubRepository.java
+++ b/src/main/java/kr/hanjari/backend/repository/ClubRepository.java
@@ -2,13 +2,30 @@ package kr.hanjari.backend.repository;
 
 import java.util.Optional;
 import kr.hanjari.backend.domain.Club;
+import kr.hanjari.backend.domain.enums.ClubCategory;
+import kr.hanjari.backend.domain.enums.RecruitmentStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ClubRepository extends JpaRepository<Club, Long> {
+public interface ClubRepository extends JpaRepository<Club, Long>, JpaSpecificationExecutor<Club> {
 
     Optional<Club> findByName(String clubName);
     Optional<Club> findByCode(String code);
     boolean existsByCode(String code);
+
+    @Query("SELECT c FROM Club c WHERE (:name IS NULL OR c.name LIKE %:name%) " +
+            "AND (:category IS NULL OR c.category = :category) " +
+            "AND (:status IS NULL OR c.recruitmentStatus = :status) " +
+            "ORDER BY " +
+            "CASE WHEN c.recruitmentStatus = 'OPEN' THEN 0 " +
+            "     WHEN c.recruitmentStatus = 'UPCOMING' THEN 1 " +
+            "     WHEN c.recruitmentStatus = 'CLOSED' THEN 2 " +
+            "     ELSE 3 END ASC, c.name ASC")
+    Page<Club> findClubsOrderByRecruitmentStatus(String name, ClubCategory category, RecruitmentStatus status, Pageable pageable);
+
 }

--- a/src/main/java/kr/hanjari/backend/repository/specification/ClubSpecifications.java
+++ b/src/main/java/kr/hanjari/backend/repository/specification/ClubSpecifications.java
@@ -1,0 +1,31 @@
+package kr.hanjari.backend.repository.specification;
+
+import jakarta.persistence.criteria.Predicate;
+import java.util.ArrayList;
+import java.util.List;
+import kr.hanjari.backend.domain.Club;
+import kr.hanjari.backend.domain.enums.ClubCategory;
+import kr.hanjari.backend.domain.enums.RecruitmentStatus;
+import org.springframework.data.jpa.domain.Specification;
+
+public class ClubSpecifications {
+
+    public static Specification<Club> findByCondition(
+            String name, ClubCategory clubCategory, RecruitmentStatus recruitmentStatus) {
+
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (name != null) {
+                predicates.add(cb.like(root.get("name"), "%" + name + "%"));
+            }
+            if (clubCategory != null) {
+                predicates.add(cb.equal(root.get("category"), clubCategory));
+            }
+            if (recruitmentStatus != null) {
+                predicates.add(cb.equal(root.get("recruitmentStatus"), recruitmentStatus));
+            }
+
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
@@ -1,5 +1,6 @@
 package kr.hanjari.backend.service.club.impl;
 
+import java.util.Comparator;
 import java.util.List;
 import kr.hanjari.backend.domain.Club;
 import kr.hanjari.backend.domain.Introduction;
@@ -14,6 +15,7 @@ import kr.hanjari.backend.repository.ClubRepository;
 import kr.hanjari.backend.repository.IntroductionRepository;
 import kr.hanjari.backend.repository.RecruitmentRepository;
 import kr.hanjari.backend.repository.ScheduleRepository;
+import kr.hanjari.backend.repository.specification.ClubSpecifications;
 import kr.hanjari.backend.service.club.ClubQueryService;
 import kr.hanjari.backend.web.dto.club.response.ClubIntroductionResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubRecruitmentResponseDTO;
@@ -22,6 +24,10 @@ import kr.hanjari.backend.web.dto.club.response.ClubScheduleResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubSearchResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,9 +44,19 @@ public class ClubQueryServiceImpl implements ClubQueryService {
 
 
     @Override
-    public ClubSearchResponseDTO findClubsByCondition(String name, ClubCategory category, RecruitmentStatus status, SortBy sortBy, int page,
-                                                      int size) {
-        return null;
+    public ClubSearchResponseDTO findClubsByCondition(
+            String name, ClubCategory category, RecruitmentStatus status, SortBy sortBy, int page,
+            int size) {
+
+        if (sortBy.equals(SortBy.RECRUITMENT_STATUS_ASC)) {
+            Page<Club> clubs = clubRepository.findClubsOrderByRecruitmentStatus(name, category, status, PageRequest.of(page, size));
+            return ClubSearchResponseDTO.of(clubs);
+        }
+
+        Sort sort = (sortBy != null) ? sortBy.getSort() : SortBy.NAME_ASC.getSort();
+        Pageable pageable = PageRequest.of(page, size, sort);
+        Page<Club> clubs = clubRepository.findAll(ClubSpecifications.findByCondition(name, category, status), pageable);
+        return ClubSearchResponseDTO.of(clubs);
     }
 
     @Override
@@ -87,4 +103,12 @@ public class ClubQueryServiceImpl implements ClubQueryService {
 
         return ClubRecruitmentResponseDTO.of(recruitment, club);
     }
+
+    private Comparator<RecruitmentStatus> recruitmentStatusComparator =
+            Comparator.comparingInt(status -> switch (status) {
+                case OPEN -> 0;
+                case UPCOMING -> 1;
+                case CLOSED -> 2;
+            });
+
 }

--- a/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
@@ -48,7 +48,7 @@ public class ClubQueryServiceImpl implements ClubQueryService {
             String name, ClubCategory category, RecruitmentStatus status, SortBy sortBy, int page,
             int size) {
 
-        if (sortBy.equals(SortBy.RECRUITMENT_STATUS_ASC)) {
+        if (sortBy != null && sortBy.equals(SortBy.RECRUITMENT_STATUS_ASC)) {
             Page<Club> clubs = clubRepository.findClubsOrderByRecruitmentStatus(name, category, status, PageRequest.of(page, size));
             return ClubSearchResponseDTO.of(clubs);
         }

--- a/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
@@ -103,12 +103,4 @@ public class ClubQueryServiceImpl implements ClubQueryService {
 
         return ClubRecruitmentResponseDTO.of(recruitment, club);
     }
-
-    private Comparator<RecruitmentStatus> recruitmentStatusComparator =
-            Comparator.comparingInt(status -> switch (status) {
-                case OPEN -> 0;
-                case UPCOMING -> 1;
-                case CLOSED -> 2;
-            });
-
 }

--- a/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
+++ b/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
@@ -3,6 +3,9 @@ package kr.hanjari.backend.web.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.hanjari.backend.domain.enums.ClubCategory;
+import kr.hanjari.backend.domain.enums.RecruitmentStatus;
+import kr.hanjari.backend.domain.enums.SortBy;
 import kr.hanjari.backend.payload.ApiResponse;
 import kr.hanjari.backend.service.club.ClubCommandService;
 import kr.hanjari.backend.service.club.ClubQueryService;
@@ -75,16 +78,18 @@ public class ClubController {
             - **sortBy**: 정렬 기준 \n
             
             ### 모든 조건은 선택적으로 입력할 수 있습니다. (필수 X)
+            아무 값도 입력 하지 않을 경우, 가나다순으로 정렬하여 전체 동아리를 조회합니다. page의 기본 값은 0, size의 기본 값은 10입니다.
             """)
     @GetMapping("")
     public ApiResponse<ClubSearchResponseDTO> getClubsByCondition(
             @RequestParam(required = false) String keyword,
-            @RequestParam(required = false) String category,
-            @RequestParam(required = false) String status,
-            @RequestParam(required = false) String sortBy
+            @RequestParam(required = false) ClubCategory category,
+            @RequestParam(required = false) RecruitmentStatus status,
+            @RequestParam(required = false) SortBy sortBy,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
     ) {
-        // TODO
-        return null;
+        return ApiResponse.onSuccess(clubQueryService.findClubsByCondition(keyword, category, status, sortBy, page, size));
     }
 
     /*----------------------------- 동아리 상세 -----------------------------*/

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubSearchResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubSearchResponseDTO.java
@@ -1,9 +1,17 @@
 package kr.hanjari.backend.web.dto.club.response;
 
 import java.util.List;
+import kr.hanjari.backend.domain.Club;
+import org.springframework.data.domain.Page;
 
 public record ClubSearchResponseDTO(
         List<ClubResponseDTO> clubs,
         int totalElements
 ) {
+    public static ClubSearchResponseDTO of(Page<Club> clubs) {
+        return new ClubSearchResponseDTO(
+                clubs.map(ClubResponseDTO::of).getContent(),
+                (int) clubs.getTotalElements()
+        );
+    }
 }


### PR DESCRIPTION
## 💻 작업사항

- `QueryDSL`을 해당 기능을 위해 도입 하기에는 적절하지 않다고 판단하여 `JPA Criteria`를 활용해 동아리 검색 기능을 구현 했습니다. 
- 정렬 조건이 `모집 기준`인 경우, 정렬 순서가 `모집중 -> 모집예정 -> 모집완료` 와 같이 정렬 되어야 합니다! 하지만 `Enum` 타입만으로는 이를 구현하기가 복잡해서 따로 직접 쿼리를 작성해서 구현 했습니다. 
- 아무 검색 조건도 입력하지 않았을 시, `가나다순`으로 동아리가 정렬 되도록 구현 했습니다. 이 부분 수정 필요하시면 말씀해주세요.

## 💡 작성한 이슈 외에 작업한 사항

- API 명세서에 기본값에 대한 추가적인 안내를 작성 했습니다.  
- JWT 토큰으로 검증 하는 부분도 구현 하려고 했으나 이 부분은 조금 논의 해야할 것 같아서 정리해서 말씀 드리겠습니다.

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
