### PR TITLE
✨[FEATURE] 인증/인가 적용 

### DIFF
--- a/src/main/java/kr/hanjari/backend/payload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/hanjari/backend/payload/code/status/ErrorStatus.java
@@ -18,6 +18,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 사용자 관련
     _TOKEN_ALREADY_LOGOUT(HttpStatus.BAD_REQUEST, "USER400", "이미 로그아웃 처리된 토큰입니다."),
+    _TOKEN_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER400", "토큰이 존재하지 않습니다."),
 
     // 동아리 관련
     _CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUB404", "동아리를 찾을 수 없습니다."),

--- a/src/main/java/kr/hanjari/backend/payload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/hanjari/backend/payload/code/status/ErrorStatus.java
@@ -14,11 +14,12 @@ public enum ErrorStatus implements BaseErrorCode {
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의해주세요."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON402", "금지된 요청입니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
     // 사용자 관련
-    _TOKEN_ALREADY_LOGOUT(HttpStatus.BAD_REQUEST, "USER400", "이미 로그아웃 처리된 토큰입니다."),
-    _TOKEN_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER400", "토큰이 존재하지 않습니다."),
+    _TOKEN_ALREADY_LOGOUT(HttpStatus.BAD_REQUEST, "USER404", "이미 로그아웃 처리된 토큰입니다."),
+    _TOKEN_NOT_EXIST(HttpStatus.UNAUTHORIZED, "USER401", "토큰이 존재하지 않습니다."),
+    _TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "USER401", "만료된 토큰입니다."),
 
     // 동아리 관련
     _CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUB404", "동아리를 찾을 수 없습니다."),

--- a/src/main/java/kr/hanjari/backend/payload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/hanjari/backend/payload/code/status/ErrorStatus.java
@@ -17,9 +17,12 @@ public enum ErrorStatus implements BaseErrorCode {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
     // 사용자 관련
-    _TOKEN_ALREADY_LOGOUT(HttpStatus.BAD_REQUEST, "USER404", "이미 로그아웃 처리된 토큰입니다."),
+    _INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "USER401", "유효하지 않은 토큰입니다."),
+    _TOKEN_ALREADY_LOGOUT(HttpStatus.BAD_REQUEST, "USER400", "이미 로그아웃 처리된 토큰입니다."),
     _TOKEN_NOT_EXIST(HttpStatus.UNAUTHORIZED, "USER401", "토큰이 존재하지 않습니다."),
     _TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "USER401", "만료된 토큰입니다."),
+    _ACCESS_DENIED(HttpStatus.FORBIDDEN, "USER403", "접근 권한이 없습니다."),
+    _INVALID_TOKEN_SIGNATURE(HttpStatus.UNAUTHORIZED, "USER401", "유효하지 않은 토큰 서명입니다."),
 
     // 동아리 관련
     _CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUB404", "동아리를 찾을 수 없습니다."),

--- a/src/main/java/kr/hanjari/backend/repository/ClubRepository.java
+++ b/src/main/java/kr/hanjari/backend/repository/ClubRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -17,6 +18,11 @@ public interface ClubRepository extends JpaRepository<Club, Long>, JpaSpecificat
     Optional<Club> findByName(String clubName);
     Optional<Club> findByCode(String code);
     boolean existsByCode(String code);
+
+    @Query("SELECT c.name FROM Club c WHERE c.id = :clubId")
+    Optional<String> findClubNameById(@Param("clubId") Long clubId);
+
+
 
     @Query("SELECT c FROM Club c WHERE (:name IS NULL OR c.name LIKE %:name%) " +
             "AND (:category IS NULL OR c.category = :category) " +

--- a/src/main/java/kr/hanjari/backend/security/auth/JwtTokenProvider.java
+++ b/src/main/java/kr/hanjari/backend/security/auth/JwtTokenProvider.java
@@ -70,7 +70,7 @@ public class JwtTokenProvider {
         String token = getToken("Authorization").substring(7);
 
         if (isTokenExpired(token)) {
-            throw new GeneralException(ErrorStatus._TOKEN_ALREADY_LOGOUT);
+            throw new GeneralException(ErrorStatus._TOKEN_EXPIRED);
         }
 
         String subject = getClubNameFromToken(token);

--- a/src/main/java/kr/hanjari/backend/security/auth/JwtTokenProvider.java
+++ b/src/main/java/kr/hanjari/backend/security/auth/JwtTokenProvider.java
@@ -20,7 +20,28 @@ public class JwtTokenProvider {
     private String SECRET_KEY;
     @Value("${jwt.expiration-time}")
     private Integer EXPIRATION_TIME; // 24시간
+    @Value("${jwt.secret.admin}")
+    private String SECRET_ADMIN;
+    @Value("${jwt.secret.service-admin}")
+    private String SECRET_SERVICE_ADMIN;
 
+    public String createAdminToken() {
+        return Jwts.builder()
+                .setSubject(SECRET_ADMIN)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME)) // 24시간 유효
+                .signWith(SignatureAlgorithm.HS512, SECRET_KEY)
+                .compact();
+    }
+
+    public String createServiceAdminToken() {
+        return Jwts.builder()
+                .setSubject(SECRET_SERVICE_ADMIN)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME)) // 24시간 유효
+                .signWith(SignatureAlgorithm.HS512, SECRET_KEY)
+                .compact();
+    }
 
     public String createToken(String clubName) {
         return Jwts.builder()

--- a/src/main/java/kr/hanjari/backend/security/auth/JwtTokenProvider.java
+++ b/src/main/java/kr/hanjari/backend/security/auth/JwtTokenProvider.java
@@ -50,20 +50,35 @@ public class JwtTokenProvider {
                 .getBody();
     }
 
-    // 접근 가능한 API인지 확인(토큰이 유효한지, 만료되지 않았는지, 동아리 관리자가 맞는지)
+    // 토큰 기반 접근 권한 검증
     public void isAccessible(String clubName) {
-        String token = getToken("Authorization");
-        token = token.substring(7);
+        validateTokenAndCheckAccess(clubName);
+    }
+
+    // 서비스 관리자 접근 권한 검증
+    public void isServiceAdminAccessible() {
+        validateTokenAndCheckAccess(SECRET_SERVICE_ADMIN);
+    }
+
+    // 총동연 관리자 접근 권한 검증
+    public void isAdminAccessible() {
+        validateTokenAndCheckAccess(SECRET_ADMIN);
+    }
+
+    // 공통 검증 로직 (중복 제거)
+    private void validateTokenAndCheckAccess(String expectedSubject) {
+        String token = getToken("Authorization").substring(7);
+
         if (isTokenExpired(token)) {
             throw new GeneralException(ErrorStatus._TOKEN_ALREADY_LOGOUT);
         }
 
-        String clubNameByToken = getClubNameFromToken(token);
-
-        if (!Objects.equals(clubName, clubNameByToken)) {
+        String subject = getClubNameFromToken(token);
+        if (!Objects.equals(subject, expectedSubject)) {
             throw new GeneralException(ErrorStatus._FORBIDDEN);
         }
     }
+
 
 
     private String getClubNameFromToken(String token) {

--- a/src/main/java/kr/hanjari/backend/security/auth/JwtTokenProvider.java
+++ b/src/main/java/kr/hanjari/backend/security/auth/JwtTokenProvider.java
@@ -1,19 +1,22 @@
 package kr.hanjari.backend.security.auth;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Date;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import kr.hanjari.backend.payload.code.status.ErrorStatus;
 import kr.hanjari.backend.payload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Service
+@RequiredArgsConstructor
 public class JwtTokenProvider {
 
     @Value("${jwt.secret-key}")
@@ -24,6 +27,10 @@ public class JwtTokenProvider {
     private String SECRET_ADMIN;
     @Value("${jwt.secret.service-admin}")
     private String SECRET_SERVICE_ADMIN;
+    @Value("${jwt.blacklist-key}")
+    private String BLACKLIST_KEY;
+
+    private final StringRedisTemplate redisTemplate;
 
     public String createAdminToken() {
         return createToken(SECRET_ADMIN);
@@ -42,47 +49,59 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-
-    public Claims validateToken(String token) {
-        return Jwts.parser()
-                .setSigningKey(SECRET_KEY)
-                .parseClaimsJws(token)
-                .getBody();
+    public void addTokenToBlacklist(String token) {
+        redisTemplate.opsForSet().add(BLACKLIST_KEY, token);
+        redisTemplate.expire(BLACKLIST_KEY, 1, TimeUnit.DAYS);
     }
 
-    // 토큰 기반 접근 권한 검증
     public void isAccessible(String clubName) {
         validateTokenAndCheckAccess(clubName);
     }
 
-    // 서비스 관리자 접근 권한 검증
     public void isServiceAdminAccessible() {
         validateTokenAndCheckAccess(SECRET_SERVICE_ADMIN);
     }
 
-    // 총동연 관리자 접근 권한 검증
     public void isAdminAccessible() {
         validateTokenAndCheckAccess(SECRET_ADMIN);
+    }
+
+    public boolean isTokenInBlacklist(String token) {
+        validateJwtToken(token);
+        return redisTemplate.opsForSet().isMember(BLACKLIST_KEY, token);
+    }
+
+
+    private Claims getClaimsFromToken(String token) {
+        try {
+            return Jwts.parser()
+                    .setSigningKey(SECRET_KEY)
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (JwtException e) {
+            throw new GeneralException(ErrorStatus._INVALID_TOKEN);
+        }
     }
 
     // 공통 검증 로직 (중복 제거)
     private void validateTokenAndCheckAccess(String expectedSubject) {
         String token = getToken("Authorization").substring(7);
 
-        if (isTokenExpired(token)) {
-            throw new GeneralException(ErrorStatus._TOKEN_EXPIRED);
+        validateJwtToken(token);
+
+        if (isTokenInBlacklist(token)) {
+            throw new GeneralException(ErrorStatus._TOKEN_ALREADY_LOGOUT);
         }
 
         String subject = getClubNameFromToken(token);
         if (!Objects.equals(subject, expectedSubject)) {
-            throw new GeneralException(ErrorStatus._FORBIDDEN);
+            throw new GeneralException(ErrorStatus._ACCESS_DENIED);
         }
     }
 
-
-
     private String getClubNameFromToken(String token) {
-        return validateToken(token).getSubject();
+        Claims claims = getClaimsFromToken(token);
+        return claims.getSubject();
     }
 
     private String getToken(String tokenName) {
@@ -98,7 +117,20 @@ public class JwtTokenProvider {
         return token;
     }
 
-    public boolean isTokenExpired(String token) {
-        return validateToken(token).getExpiration().before(new Date());
+    private void validateJwtToken(String token) {
+        try {
+            // JWT 유효성 검증 로직 (예: 서명, 만료일자, 포맷 등)
+            // 예시: 토큰을 파싱하고 서명 검증
+            Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token);
+        } catch (ExpiredJwtException e) {
+            throw new GeneralException(ErrorStatus._TOKEN_EXPIRED);
+        } catch (SignatureException e) {
+            throw new GeneralException(ErrorStatus._INVALID_TOKEN_SIGNATURE);
+        } catch (MalformedJwtException e) {
+            throw new GeneralException(ErrorStatus._INVALID_TOKEN);
+        } catch (JwtException e) {
+            throw new GeneralException(ErrorStatus._INVALID_TOKEN);
+        }
     }
+
 }

--- a/src/main/java/kr/hanjari/backend/security/auth/JwtTokenProvider.java
+++ b/src/main/java/kr/hanjari/backend/security/auth/JwtTokenProvider.java
@@ -26,31 +26,22 @@ public class JwtTokenProvider {
     private String SECRET_SERVICE_ADMIN;
 
     public String createAdminToken() {
-        return Jwts.builder()
-                .setSubject(SECRET_ADMIN)
-                .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME)) // 24시간 유효
-                .signWith(SignatureAlgorithm.HS512, SECRET_KEY)
-                .compact();
+        return createToken(SECRET_ADMIN);
     }
 
     public String createServiceAdminToken() {
+        return createToken(SECRET_SERVICE_ADMIN);
+    }
+
+    public String createToken(String subject) {
         return Jwts.builder()
-                .setSubject(SECRET_SERVICE_ADMIN)
+                .setSubject(subject)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME)) // 24시간 유효
                 .signWith(SignatureAlgorithm.HS512, SECRET_KEY)
                 .compact();
     }
 
-    public String createToken(String clubName) {
-        return Jwts.builder()
-                .setSubject(clubName)
-                .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME)) // 24시간 유효
-                .signWith(SignatureAlgorithm.HS512, SECRET_KEY)
-                .compact();
-    }
 
     public Claims validateToken(String token) {
         return Jwts.parser()

--- a/src/main/java/kr/hanjari/backend/service/activity/impl/ActivityServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/activity/impl/ActivityServiceImpl.java
@@ -11,6 +11,7 @@ import kr.hanjari.backend.payload.exception.GeneralException;
 import kr.hanjari.backend.repository.ActivityImageRepository;
 import kr.hanjari.backend.repository.ActivityRepository;
 import kr.hanjari.backend.repository.ClubRepository;
+import kr.hanjari.backend.security.auth.JwtTokenProvider;
 import kr.hanjari.backend.service.activity.ActivityService;
 import kr.hanjari.backend.service.s3.S3Service;
 import kr.hanjari.backend.web.dto.activity.request.CreateActivityRequest;
@@ -31,9 +32,11 @@ import java.util.stream.IntStream;
 @RequiredArgsConstructor
 public class ActivityServiceImpl implements ActivityService {
 
+    //TODO 활동 로그 인증/인가 적용 -> 현재 Club 관련 정보 X
     private final ActivityRepository activityRepository;
     private final ActivityImageRepository activityImageRepository;
     private final ClubRepository clubRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
     private final S3Service s3Service;
 
@@ -44,6 +47,7 @@ public class ActivityServiceImpl implements ActivityService {
         Club club = clubRepository.findById(clubId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
 
+        jwtTokenProvider.isAccessible(club.getName());
         newActivity.setClub(club);
         activityRepository.save(newActivity);
 
@@ -70,6 +74,7 @@ public class ActivityServiceImpl implements ActivityService {
 
         activity.updateContentAndDate(updateActivityRequest.content(), updateActivityRequest.date());
 
+        // jwtTokenProvider.isAccessible(club.getName());
         List<ActivityImage> activityImageList = activityImageRepository.findAllByActivityIdOrderByOrderIndexAsc(activityId);
 
         if (!images.isEmpty()) {
@@ -102,6 +107,8 @@ public class ActivityServiceImpl implements ActivityService {
             throw new GeneralException(ErrorStatus._BAD_REQUEST);
         }
 
+
+//        jwtTokenProvider.isAccessible(club.getName());
         List<ActivityImage> activityImages = activityImageRepository.findAllByActivityId(activityId);
         activityImages.forEach(
                 activityImage -> {

--- a/src/main/java/kr/hanjari/backend/service/announcement/impl/AnnouncementServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/announcement/impl/AnnouncementServiceImpl.java
@@ -5,6 +5,7 @@ import kr.hanjari.backend.domain.File;
 import kr.hanjari.backend.payload.code.status.ErrorStatus;
 import kr.hanjari.backend.payload.exception.GeneralException;
 import kr.hanjari.backend.repository.AnnouncementRepository;
+import kr.hanjari.backend.security.auth.JwtTokenProvider;
 import kr.hanjari.backend.service.announcement.AnnouncementService;
 import kr.hanjari.backend.service.s3.S3Service;
 import kr.hanjari.backend.web.dto.announcement.request.CommonAnnouncementRequest;
@@ -21,9 +22,12 @@ import java.util.List;
 public class AnnouncementServiceImpl implements AnnouncementService {
 
     private final AnnouncementRepository announcementRepository;
+    private final JwtTokenProvider jwtTokenProvider;
     private final S3Service s3Service;
 
     public Long createAnnouncement(CommonAnnouncementRequest commonAnnouncementRequest, MultipartFile thumbnail) {
+        jwtTokenProvider.isAdminAccessible();
+
         Announcement newAnnouncement = commonAnnouncementRequest.toAnnouncement();
         File thumbnailImage = s3Service.uploadFile(thumbnail);
 
@@ -34,6 +38,8 @@ public class AnnouncementServiceImpl implements AnnouncementService {
     }
 
     public void updateAnnouncement(Long announcementId, CommonAnnouncementRequest commonAnnouncementRequest, MultipartFile thumbnail) {
+        jwtTokenProvider.isAdminAccessible();
+
         Announcement announcement = announcementRepository.findById(announcementId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._BAD_REQUEST)); // TODO: 예외
 
@@ -47,6 +53,8 @@ public class AnnouncementServiceImpl implements AnnouncementService {
     }
 
     public void deleteAnnouncement(Long announcementId) {
+        jwtTokenProvider.isAdminAccessible();
+
         Announcement announcement = announcementRepository.findById(announcementId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._BAD_REQUEST));
 

--- a/src/main/java/kr/hanjari/backend/service/club/impl/ClubCommandServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/club/impl/ClubCommandServiceImpl.java
@@ -11,6 +11,7 @@ import kr.hanjari.backend.repository.ClubRepository;
 import kr.hanjari.backend.repository.IntroductionRepository;
 import kr.hanjari.backend.repository.RecruitmentRepository;
 import kr.hanjari.backend.repository.ScheduleRepository;
+import kr.hanjari.backend.security.auth.JwtTokenProvider;
 import kr.hanjari.backend.service.club.ClubCommandService;
 import kr.hanjari.backend.web.dto.club.request.ClubDetailRequestDTO;
 import kr.hanjari.backend.web.dto.club.request.ClubIntroductionRequestDTO;
@@ -32,10 +33,12 @@ public class ClubCommandServiceImpl implements ClubCommandService {
     private final IntroductionRepository introductionRepository;
     private final RecruitmentRepository recruitmentRepository;
     private final ScheduleRepository scheduleRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Override
     public Long saveClubDetail(Long clubId, ClubDetailRequestDTO clubDetailDTO) {
         Club club = clubRepository.findById(clubId).orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
+        jwtTokenProvider.isAccessible(club.getName());
         club.updateClubDetails(clubDetailDTO);
         Club saved = clubRepository.save(club);
         return saved.getId();
@@ -44,6 +47,7 @@ public class ClubCommandServiceImpl implements ClubCommandService {
     @Override
     public ScheduleResponseDTO saveClubSchedule(Long clubId, ClubScheduleRequestDTO clubScheduleDTO) {
         Club club = clubRepository.findById(clubId).orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
+        jwtTokenProvider.isAccessible(club.getName());
 
         Schedule schedule = Schedule.builder()
                 .club(club)
@@ -60,6 +64,7 @@ public class ClubCommandServiceImpl implements ClubCommandService {
         Club club = clubRepository.findById(clubId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
 
+        jwtTokenProvider.isAccessible(club.getName());
         Schedule schedule = scheduleRepository.findById(scheduleId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._SCHEDULE_NOT_FOUND));
 
@@ -79,6 +84,7 @@ public class ClubCommandServiceImpl implements ClubCommandService {
     public void deleteClubSchedule(Long clubId, Long scheduleId) {
         Club club = clubRepository.findById(clubId).orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
 
+        jwtTokenProvider.isAccessible(club.getName());
         Schedule schedule = scheduleRepository.findById(scheduleId).orElseThrow(() -> new GeneralException(ErrorStatus._SCHEDULE_NOT_FOUND));
 
         if (!club.getId().equals(schedule.getClub().getId())) {
@@ -98,6 +104,12 @@ public class ClubCommandServiceImpl implements ClubCommandService {
         // 기존 Introduction 조회
         Introduction introduction = introductionRepository.findById(clubId)
                 .orElseGet(() -> Introduction.builder().clubId(clubId).build());
+
+        // 클럽의 이름만 조회
+        String clubName = clubRepository.findClubNameById(clubId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
+
+        jwtTokenProvider.isAccessible(clubName);
 
         // Introduction 내용 업데이트
         introduction.updateIntroduction(clubIntroductionDTO.introduction(),
@@ -119,6 +131,12 @@ public class ClubCommandServiceImpl implements ClubCommandService {
 
         Recruitment recruitment = recruitmentRepository.findById(clubId)
                 .orElseGet(() -> Recruitment.builder().clubId(clubId).build());
+
+        // 클럽의 이름만 조회
+        String clubName = clubRepository.findClubNameById(clubId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
+
+        jwtTokenProvider.isAccessible(clubName);
 
         recruitment.updateRecruitment(clubRecruitmentDTO);
 

--- a/src/main/java/kr/hanjari/backend/service/document/impl/DocumentServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/document/impl/DocumentServiceImpl.java
@@ -9,6 +9,7 @@ import kr.hanjari.backend.payload.code.status.ErrorStatus;
 import kr.hanjari.backend.payload.exception.GeneralException;
 import kr.hanjari.backend.repository.DocumentFileRepository;
 import kr.hanjari.backend.repository.DocumentRepository;
+import kr.hanjari.backend.security.auth.JwtTokenProvider;
 import kr.hanjari.backend.service.document.DocumentService;
 import kr.hanjari.backend.service.s3.S3Service;
 import kr.hanjari.backend.web.dto.document.DocumentDTO;
@@ -30,6 +31,7 @@ public class DocumentServiceImpl implements DocumentService {
 
     private final DocumentRepository documentRepository;
     private final DocumentFileRepository documentFileRepository;
+    private final JwtTokenProvider jwtTokenProvider;
     private final S3Service s3Service;
 
     public GetAllDocumentsResponse getAllDocuments() {
@@ -65,6 +67,7 @@ public class DocumentServiceImpl implements DocumentService {
     public Long createDocument(CreateDocumentRequest request,
                                List<MultipartFile> files) {
 
+        jwtTokenProvider.isAdminAccessible();
         Document newDocument = request.toEntity();
         documentRepository.save(newDocument);
 
@@ -85,6 +88,7 @@ public class DocumentServiceImpl implements DocumentService {
 
     public void deleteDocument(Long documentId) {
 
+        jwtTokenProvider.isAdminAccessible();
         List<DocumentFile> documentFiles = documentFileRepository.findAllByDocumentId(documentId);
         documentFileRepository.deleteAll(documentFiles);
         documentRepository.deleteById(documentId);
@@ -98,6 +102,7 @@ public class DocumentServiceImpl implements DocumentService {
 
     public void updateDocument(Long documentId, UpdateDocumentRequest request, List<MultipartFile> files) {
 
+        jwtTokenProvider.isAdminAccessible();
         Document document = documentRepository.findById(documentId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._BAD_REQUEST)); // TODO: 예외 추가
 

--- a/src/main/java/kr/hanjari/backend/service/serviceAnnouncement/impl/ServiceAnnouncementCommandServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/serviceAnnouncement/impl/ServiceAnnouncementCommandServiceImpl.java
@@ -23,6 +23,9 @@ public class ServiceAnnouncementCommandServiceImpl implements ServiceAnnouncemen
 
     @Override
     public Long createServiceAnnouncement(CreateServiceAnnouncementRequestDTO requestDTO) {
+
+        jwtTokenProvider.isServiceAdminAccessible();
+
         ServiceAnnouncement serviceAnnouncement = ServiceAnnouncement.builder()
                 .title(requestDTO.title())
                 .content(requestDTO.content())
@@ -34,6 +37,9 @@ public class ServiceAnnouncementCommandServiceImpl implements ServiceAnnouncemen
 
     @Override
     public Long updateServiceAnnouncement(Long id, CreateServiceAnnouncementRequestDTO requestDTO) {
+
+        jwtTokenProvider.isServiceAdminAccessible();
+
         ServiceAnnouncement serviceAnnouncement = serviceAnnouncementRepository.findById(id)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._SERVICE_ANNOUNCEMENT_NOT_FOUND));
 
@@ -45,6 +51,9 @@ public class ServiceAnnouncementCommandServiceImpl implements ServiceAnnouncemen
 
     @Override
     public void deleteServiceAnnouncement(Long id) {
+
+        jwtTokenProvider.isServiceAdminAccessible();
+
         ServiceAnnouncement serviceAnnouncement = serviceAnnouncementRepository.findById(id)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._SERVICE_ANNOUNCEMENT_NOT_FOUND));
 

--- a/src/main/java/kr/hanjari/backend/service/serviceAnnouncement/impl/ServiceAnnouncementCommandServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/serviceAnnouncement/impl/ServiceAnnouncementCommandServiceImpl.java
@@ -4,6 +4,7 @@ import kr.hanjari.backend.domain.ServiceAnnouncement;
 import kr.hanjari.backend.payload.code.status.ErrorStatus;
 import kr.hanjari.backend.payload.exception.GeneralException;
 import kr.hanjari.backend.repository.ServiceAnnouncementRepository;
+import kr.hanjari.backend.security.auth.JwtTokenProvider;
 import kr.hanjari.backend.service.serviceAnnouncement.ServiceAnnouncementCommandService;
 import kr.hanjari.backend.web.dto.serviceAnnouncement.request.CreateServiceAnnouncementRequestDTO;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ServiceAnnouncementCommandServiceImpl implements ServiceAnnouncementCommandService {
 
     private final ServiceAnnouncementRepository serviceAnnouncementRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Override
     public Long createServiceAnnouncement(CreateServiceAnnouncementRequestDTO requestDTO) {

--- a/src/main/java/kr/hanjari/backend/service/user/UserCommandService.java
+++ b/src/main/java/kr/hanjari/backend/service/user/UserCommandService.java
@@ -15,7 +15,4 @@ public interface UserCommandService {
     // 로그아웃
     void logout(String authorizationHeader);
 
-    // 토큰이 블랙리스트에 있는지 확인
-    boolean isContainToken(String token);
-
 }

--- a/src/main/java/kr/hanjari/backend/service/user/impl/UserCommandServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/user/impl/UserCommandServiceImpl.java
@@ -61,11 +61,11 @@ public class UserCommandServiceImpl implements UserCommandService {
     @Override
     public UserLoginResponseDTO login(UserLoginRequestDTO request) {
         if (request.code().equals(SERVICE_ADMIN_CODE)) {
-            return UserLoginResponseDTO.of(jwtTokenProvider.createServiceAdminToken(), "서비스 관리자", request.code());
+            return UserLoginResponseDTO.of(jwtTokenProvider.createServiceAdminToken(), "서비스 관리자");
         }
 
         if (request.code().equals(ADMIN_CODE)) {
-            return UserLoginResponseDTO.of(jwtTokenProvider.createAdminToken(), "총동아리연합회", request.code());
+            return UserLoginResponseDTO.of(jwtTokenProvider.createAdminToken(), "총동아리연합회");
         }
 
         Club club = clubRepository.findByCode(request.code()).orElseThrow(
@@ -73,7 +73,7 @@ public class UserCommandServiceImpl implements UserCommandService {
 
         String accessToken = jwtTokenProvider.createToken(club.getName());
 
-        return UserLoginResponseDTO.of(accessToken, club.getName(), request.code());
+        return UserLoginResponseDTO.of(accessToken, club.getName());
     }
 
     @Override

--- a/src/main/java/kr/hanjari/backend/service/user/impl/UserCommandServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/user/impl/UserCommandServiceImpl.java
@@ -1,7 +1,6 @@
 package kr.hanjari.backend.service.user.impl;
 
 import java.security.SecureRandom;
-import java.util.concurrent.TimeUnit;
 import kr.hanjari.backend.domain.Club;
 import kr.hanjari.backend.payload.code.status.ErrorStatus;
 import kr.hanjari.backend.payload.exception.GeneralException;
@@ -14,10 +13,8 @@ import kr.hanjari.backend.web.dto.user.response.UserLoginResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import software.amazon.awssdk.services.s3.endpoints.internal.Value.Str;
 
 @Slf4j
 @Service
@@ -26,7 +23,6 @@ import software.amazon.awssdk.services.s3.endpoints.internal.Value.Str;
 public class UserCommandServiceImpl implements UserCommandService {
 
     private final ClubRepository clubRepository;
-    private final StringRedisTemplate redisTemplate;
     private final JwtTokenProvider jwtTokenProvider;
 
     @Value("${service.admin}")
@@ -34,7 +30,6 @@ public class UserCommandServiceImpl implements UserCommandService {
     @Value("${admin}")
     private String ADMIN_CODE;
 
-    private static final String BLACKLIST_KEY = "blacklist";
     private static final String CHAR_POOL = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"; // 코드에 사용할 문자 집합
     private static final int CODE_LENGTH = 6; // 코드 길이
 
@@ -79,23 +74,11 @@ public class UserCommandServiceImpl implements UserCommandService {
     @Override
     public void logout(String authorizationHeader) {
         String token = authorizationHeader.substring(7); // "Bearer " 제거
-        if (jwtTokenProvider.isTokenExpired(token))  {
-            return; // 만료된 토큰은 블랙리스트에 추가하지 않음
-        }
-        if (isContainToken(token)) {
+        if (jwtTokenProvider.isTokenInBlacklist(token)) {
             throw new GeneralException(ErrorStatus._TOKEN_ALREADY_LOGOUT);
         }
-        // Redis 블랙리스트에 토큰 추가
-        redisTemplate.opsForSet().add(BLACKLIST_KEY, token);
-        // 예시로 만료시간 설정 (1일)
-        redisTemplate.expire(BLACKLIST_KEY, 1, TimeUnit.DAYS);
+        jwtTokenProvider.addTokenToBlacklist(token);
     }
-
-    @Override
-    public boolean isContainToken(String token) {
-        return redisTemplate.opsForSet().isMember(BLACKLIST_KEY, token);
-    }
-
 
     private String generateRandomCode() {
         StringBuilder codeBuilder = new StringBuilder(CODE_LENGTH);

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubSearchResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubSearchResponseDTO.java
@@ -11,7 +11,7 @@ public record ClubSearchResponseDTO(
     public static ClubSearchResponseDTO of(Page<Club> clubs) {
         return new ClubSearchResponseDTO(
                 clubs.map(ClubResponseDTO::of).getContent(),
-                (int) clubs.getTotalElements()
+                clubs.getNumberOfElements()
         );
     }
 }

--- a/src/main/java/kr/hanjari/backend/web/dto/user/response/UserLoginResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/user/response/UserLoginResponseDTO.java
@@ -1,7 +1,7 @@
 package kr.hanjari.backend.web.dto.user.response;
 
-public record UserLoginResponseDTO(String accessToken, String clubName, String code) {
-    public static UserLoginResponseDTO of(String accessToken, String clubName, String code) {
-        return new UserLoginResponseDTO(accessToken, clubName, code);
+public record UserLoginResponseDTO(String accessToken, String clubName) {
+    public static UserLoginResponseDTO of(String accessToken, String clubName) {
+        return new UserLoginResponseDTO(accessToken, clubName);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,6 +33,7 @@ spring.data.redis.port=${REDIS_PORT}
 jwt.secret-key=${JWT_SECRET_KEY}
 jwt.secret.admin=${JWT_ADMIN_SECRET}
 jwt.secret.service-admin=${JWT_SERVICE_ADMIN_SECRET}
+jwt.blacklist-key=${JWT_BLACKLIST_KEY}
 
 jwt.expiration-time=${JWT_EXPIRATION_TIME}
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,4 +31,11 @@ spring.data.redis.port=${REDIS_PORT}
 
 # JWT
 jwt.secret-key=${JWT_SECRET_KEY}
+jwt.secret.admin=${JWT_ADMIN_SECRET}
+jwt.secret.service-admin=${JWT_SERVICE_ADMIN_SECRET}
+
 jwt.expiration-time=${JWT_EXPIRATION_TIME}
+
+# Admin
+service.admin=${SERVICE_ADMIN}
+admin=${ADMIN}


### PR DESCRIPTION
## 💻 작업사항

- 동아리 관련 생성/수정/삭제 API : 해당 동아리 접근 권한 있는 사용자만 호출 가능
- 총동연, 서비스 관리 관련 생성/수정/삭제 API : 해당 부분도 접근 권한 있는 사용자만 호출 가능 
- 활동 로그 관련 API는 클럽 관련 정보를 받아올 방법이 마땅히 보이지 않아서 우선 주석 처리 했습니다. 
- 관련 사용 방법은 노션에도 정리 했으니 확인 부탁드립니다. 
- `.env` 파일 관련 변경 사항도 노션에 반영 했습니다. 

## 💡 작성한 이슈 외에 작업한 사항

- `Document`랑 `Announcement` 관련 API 최대한 꼼꼼히 테스트 했는데, 혹시나 예상치 못한 문제가 발생 하면 말씀 부탁드립니다.
- 로그아웃 관련 로직은 `UserCommandService` 에서 `JwtTokenProvider`로 옮겼습니다.

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
