### PR TITLE
:bug: [FIX] 서비스 공지사항 페이징 조회 시, 정확한 갯수 반환하도록 수정 

### DIFF
--- a/src/main/java/kr/hanjari/backend/web/dto/serviceAnnouncement/response/ServiceAnnouncementSearchDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/serviceAnnouncement/response/ServiceAnnouncementSearchDTO.java
@@ -11,7 +11,7 @@ public record ServiceAnnouncementSearchDTO(
     public static ServiceAnnouncementSearchDTO of(Page<ServiceAnnouncement> serviceAnnouncements) {
         return new ServiceAnnouncementSearchDTO(
                 serviceAnnouncements.map(ServiceAnnouncementDetailDTO::of).getContent(),
-                (int) serviceAnnouncements.getTotalElements()
+                serviceAnnouncements.getNumberOfElements()
         );
     }
 }


### PR DESCRIPTION
## 💻 작업사항

- 현재 서비스 공지사항 조회 시, 페이징 조회 한 공지사항의 갯수가 아닌 전체 공지사항의 갯수를 반환하는 오류 발견
-  DTO 내 `of` 메서드 수정하여 해당 오류 해결

## ✔️ check list
- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
