### PR TITLE
✨ [FEATURE] 동아리 소개글, 모집 안내 임시저장 API 구현

### DIFF
--- a/src/main/java/kr/hanjari/backend/domain/draft/IntroductionDraft.java
+++ b/src/main/java/kr/hanjari/backend/domain/draft/IntroductionDraft.java
@@ -1,0 +1,37 @@
+package kr.hanjari.backend.domain.draft;
+
+
+import jakarta.persistence.*;
+import kr.hanjari.backend.domain.Club;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Builder
+@Table(name = "introduction")
+@NoArgsConstructor
+@AllArgsConstructor
+public class IntroductionDraft {
+
+    @Id
+    @Column(name = "club_id", nullable = false)
+    private Long clubId;
+
+    @MapsId("clubId")
+    @OneToOne
+    @JoinColumn(name = "club_id")
+    private Club club;
+
+    @Column(name = "content1")
+    private String content1;
+
+    @Column(name = "content2")
+    private String content2;
+
+    @Column(name = "content3")
+    private String content3;
+
+}

--- a/src/main/java/kr/hanjari/backend/domain/draft/IntroductionDraft.java
+++ b/src/main/java/kr/hanjari/backend/domain/draft/IntroductionDraft.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Builder
-@Table(name = "introduction")
+@Table(name = "introduction_draft")
 @NoArgsConstructor
 @AllArgsConstructor
 public class IntroductionDraft {
@@ -33,5 +33,11 @@ public class IntroductionDraft {
 
     @Column(name = "content3")
     private String content3;
+
+    public void updateIntroduction(String content1, String content2, String content3 ) {
+        this.content1 = content1;
+        this.content2 = content2;
+        this.content3 = content3;
+    }
 
 }

--- a/src/main/java/kr/hanjari/backend/domain/draft/RecruitmentDraft.java
+++ b/src/main/java/kr/hanjari/backend/domain/draft/RecruitmentDraft.java
@@ -1,0 +1,37 @@
+package kr.hanjari.backend.domain.draft;
+
+import jakarta.persistence.*;
+import kr.hanjari.backend.domain.Club;
+import kr.hanjari.backend.web.dto.club.request.ClubRecruitmentRequestDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Builder
+@Table(name = "recruitment")
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecruitmentDraft {
+
+    @Id
+    @Column(name = "club_id", nullable = false)
+    private Long clubId;
+
+    @MapsId("clubId")
+    @OneToOne
+    @JoinColumn(name = "club_id")
+    private Club club;
+
+    @Column(name = "content1")
+    private String content1;
+
+    @Column(name = "content2")
+    private String content2;
+
+    @Column(name = "content3")
+    private String content3;
+
+}

--- a/src/main/java/kr/hanjari/backend/domain/draft/RecruitmentDraft.java
+++ b/src/main/java/kr/hanjari/backend/domain/draft/RecruitmentDraft.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Builder
-@Table(name = "recruitment")
+@Table(name = "recruitment_draft")
 @NoArgsConstructor
 @AllArgsConstructor
 public class RecruitmentDraft {
@@ -33,5 +33,11 @@ public class RecruitmentDraft {
 
     @Column(name = "content3")
     private String content3;
+
+    public void updateRecruitment(ClubRecruitmentRequestDTO clubRecruitmentDTO) {
+        this.content1 = clubRecruitmentDTO.due();
+        this.content2 = clubRecruitmentDTO.notice();
+        this.content3 = clubRecruitmentDTO.etc();
+    }
 
 }

--- a/src/main/java/kr/hanjari/backend/payload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/hanjari/backend/payload/code/status/ErrorStatus.java
@@ -36,6 +36,9 @@ public enum ErrorStatus implements BaseErrorCode {
     _INTRODUCTION_NOT_FOUND(HttpStatus.NOT_FOUND, "INTRODUCTION404", "소개를 찾을 수 없습니다."),
     _INTRODUCTION_DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "INTRODUCTION404", "임시 저장 된 소개를 찾을 수 없습니다."),
 
+    _RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "RECRUITMENT404", "동아리 모집 안내를 찾을 수 없습니다."),
+    _RECRUITMENT_DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "RECRUITMENT404", "임시 저장 된 동아리 모집 안내를 찾을 수 없습니다."),
+
     _SERVICE_ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "SERVICE_ANNOUNCEMENT404", "공지사항을 찾을 수 없습니다."),;
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/kr/hanjari/backend/payload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/hanjari/backend/payload/code/status/ErrorStatus.java
@@ -34,6 +34,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _SCHEDULE_TO_CHANGE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "ACTIVITY400", "변경할 월에 활동이 이미 존재합니다."),
 
     _INTRODUCTION_NOT_FOUND(HttpStatus.NOT_FOUND, "INTRODUCTION404", "소개를 찾을 수 없습니다."),
+    _INTRODUCTION_DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "INTRODUCTION404", "임시 저장 된 소개를 찾을 수 없습니다."),
 
     _SERVICE_ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "SERVICE_ANNOUNCEMENT404", "공지사항을 찾을 수 없습니다."),;
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/hanjari/backend/repository/draft/IntroductionDraftRepository.java
+++ b/src/main/java/kr/hanjari/backend/repository/draft/IntroductionDraftRepository.java
@@ -1,9 +1,14 @@
 package kr.hanjari.backend.repository.draft;
 
+import java.util.Optional;
 import kr.hanjari.backend.domain.draft.IntroductionDraft;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface IntroductionDraftRepository extends JpaRepository<IntroductionDraft, Long> {
+
+    Optional<IntroductionDraft> findByClubId(Long clubId);
+    boolean existsByClubId(Long clubId);
+    void removeByClubId(Long clubId);
 }

--- a/src/main/java/kr/hanjari/backend/repository/draft/IntroductionDraftRepository.java
+++ b/src/main/java/kr/hanjari/backend/repository/draft/IntroductionDraftRepository.java
@@ -1,0 +1,9 @@
+package kr.hanjari.backend.repository.draft;
+
+import kr.hanjari.backend.domain.draft.IntroductionDraft;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IntroductionDraftRepository extends JpaRepository<IntroductionDraft, Long> {
+}

--- a/src/main/java/kr/hanjari/backend/repository/draft/RecruitmentDraftRepository.java
+++ b/src/main/java/kr/hanjari/backend/repository/draft/RecruitmentDraftRepository.java
@@ -1,0 +1,13 @@
+package kr.hanjari.backend.repository.draft;
+
+import java.util.Optional;
+import kr.hanjari.backend.domain.draft.RecruitmentDraft;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecruitmentDraftRepository extends JpaRepository<RecruitmentDraft, Long> {
+    Optional<RecruitmentDraft> findByClubId(Long clubId);
+    boolean existsByClubId(Long clubId);
+    void removeByClubId(Long clubId);
+}

--- a/src/main/java/kr/hanjari/backend/repository/draft/RecruitmentRepository.java
+++ b/src/main/java/kr/hanjari/backend/repository/draft/RecruitmentRepository.java
@@ -1,9 +1,0 @@
-package kr.hanjari.backend.repository.draft;
-
-import kr.hanjari.backend.domain.draft.RecruitmentDraft;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface RecruitmentRepository extends JpaRepository<RecruitmentDraft, Long> {
-}

--- a/src/main/java/kr/hanjari/backend/repository/draft/RecruitmentRepository.java
+++ b/src/main/java/kr/hanjari/backend/repository/draft/RecruitmentRepository.java
@@ -1,0 +1,9 @@
+package kr.hanjari.backend.repository.draft;
+
+import kr.hanjari.backend.domain.draft.RecruitmentDraft;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecruitmentRepository extends JpaRepository<RecruitmentDraft, Long> {
+}

--- a/src/main/java/kr/hanjari/backend/service/club/ClubCommandService.java
+++ b/src/main/java/kr/hanjari/backend/service/club/ClubCommandService.java
@@ -20,9 +20,11 @@ public interface ClubCommandService {
 
     // 동아리 소개
     Long saveClubIntroduction(Long clubId, ClubIntroductionRequestDTO introduction);
+    Long saveClubIntroductionDraft(Long clubId, ClubIntroductionRequestDTO introduction);
 
     // 동아리 모집 안내
     Long saveClubRecruitment(Long clubId, ClubRecruitmentRequestDTO recruitment);
+    Long saveClubRecruitmentDraft(Long clubId, ClubRecruitmentRequestDTO recruitment);
 
 }
 

--- a/src/main/java/kr/hanjari/backend/service/club/ClubQueryService.java
+++ b/src/main/java/kr/hanjari/backend/service/club/ClubQueryService.java
@@ -4,6 +4,7 @@ package kr.hanjari.backend.service.club;
 import kr.hanjari.backend.domain.enums.ClubCategory;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 import kr.hanjari.backend.domain.enums.SortBy;
+import kr.hanjari.backend.web.dto.club.response.ClubIntroductionDraftResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubIntroductionResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubRecruitmentResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubResponseDTO;
@@ -25,7 +26,9 @@ public interface ClubQueryService {
 
     // 동아리 소개 조회
     ClubIntroductionResponseDTO findClubIntroduction(Long clubId);
+    ClubIntroductionDraftResponseDTO findClubIntroductionDraft(Long clubId);
 
     // 동아리 모집 안내
     ClubRecruitmentResponseDTO findClubRecruitment(Long clubId);
+    ClubRecruitmentResponseDTO findClubRecruitmentDraft(Long clubId);
 }

--- a/src/main/java/kr/hanjari/backend/service/club/ClubQueryService.java
+++ b/src/main/java/kr/hanjari/backend/service/club/ClubQueryService.java
@@ -6,6 +6,7 @@ import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 import kr.hanjari.backend.domain.enums.SortBy;
 import kr.hanjari.backend.web.dto.club.response.ClubIntroductionDraftResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubIntroductionResponseDTO;
+import kr.hanjari.backend.web.dto.club.response.ClubRecruitmentDraftResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubRecruitmentResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubScheduleResponseDTO;
@@ -30,5 +31,5 @@ public interface ClubQueryService {
 
     // 동아리 모집 안내
     ClubRecruitmentResponseDTO findClubRecruitment(Long clubId);
-    ClubRecruitmentResponseDTO findClubRecruitmentDraft(Long clubId);
+    ClubRecruitmentDraftResponseDTO findClubRecruitmentDraft(Long clubId);
 }

--- a/src/main/java/kr/hanjari/backend/service/club/impl/ClubCommandServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/club/impl/ClubCommandServiceImpl.java
@@ -2,9 +2,13 @@ package kr.hanjari.backend.service.club.impl;
 
 
 import kr.hanjari.backend.domain.*;
+import kr.hanjari.backend.domain.draft.IntroductionDraft;
+import kr.hanjari.backend.domain.draft.RecruitmentDraft;
 import kr.hanjari.backend.payload.code.status.ErrorStatus;
 import kr.hanjari.backend.payload.exception.GeneralException;
 import kr.hanjari.backend.repository.*;
+import kr.hanjari.backend.repository.draft.IntroductionDraftRepository;
+import kr.hanjari.backend.repository.draft.RecruitmentDraftRepository;
 import kr.hanjari.backend.security.auth.JwtTokenProvider;
 import kr.hanjari.backend.service.club.ClubCommandService;
 import kr.hanjari.backend.service.s3.S3Service;
@@ -27,6 +31,10 @@ public class ClubCommandServiceImpl implements ClubCommandService {
     private final IntroductionRepository introductionRepository;
     private final RecruitmentRepository recruitmentRepository;
     private final ScheduleRepository scheduleRepository;
+
+    private final IntroductionDraftRepository introductionDraftRepository;
+    private final RecruitmentDraftRepository recruitmentDraftRepository;
+
     private final JwtTokenProvider jwtTokenProvider;
 
     private final S3Service s3Service;
@@ -126,11 +134,7 @@ public class ClubCommandServiceImpl implements ClubCommandService {
         Introduction introduction = introductionRepository.findById(clubId)
                 .orElseGet(() -> Introduction.builder().clubId(clubId).build());
 
-        // 클럽의 이름만 조회
-        String clubName = clubRepository.findClubNameById(clubId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
-
-        jwtTokenProvider.isAccessible(clubName);
+        checkAuthorizationByClubId(clubId);
 
         // Introduction 내용 업데이트
         introduction.updateIntroduction(clubIntroductionDTO.introduction(),
@@ -139,8 +143,35 @@ public class ClubCommandServiceImpl implements ClubCommandService {
         // 저장
         Introduction saved = introductionRepository.save(introduction);
 
+        if (introductionDraftRepository.existsByClubId(clubId)) {
+            introductionDraftRepository.removeByClubId(clubId);
+        }
+
         return saved.getClubId();
     }
+
+    @Override
+    public Long saveClubIntroductionDraft(Long clubId, ClubIntroductionRequestDTO clubIntroductionDTO) {
+        if (!clubRepository.existsById(clubId)) {
+            throw new GeneralException(ErrorStatus._CLUB_NOT_FOUND);
+        }
+
+        // 기존 IntroductionDraft 조회
+        IntroductionDraft introductionDraft = introductionDraftRepository.findById(clubId)
+                .orElseGet(() -> IntroductionDraft.builder().clubId(clubId).build());
+
+        checkAuthorizationByClubId(clubId);
+
+        // IntroductionDraft 내용 업데이트
+        introductionDraft.updateIntroduction(clubIntroductionDTO.introduction(),
+                clubIntroductionDTO.activities(), clubIntroductionDTO.recruitment());
+
+        // 저장
+        IntroductionDraft saved = introductionDraftRepository.save(introductionDraft);
+
+        return saved.getClubId();
+    }
+
 
 
     @Override
@@ -154,15 +185,24 @@ public class ClubCommandServiceImpl implements ClubCommandService {
                 .orElseGet(() -> Recruitment.builder().clubId(clubId).build());
 
         // 클럽의 이름만 조회
-        String clubName = clubRepository.findClubNameById(clubId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
-
-        jwtTokenProvider.isAccessible(clubName);
+        checkAuthorizationByClubId(clubId);
 
         recruitment.updateRecruitment(clubRecruitmentDTO);
 
         Recruitment save = recruitmentRepository.save(recruitment);
 
         return save.getClubId();
+    }
+    @Override
+    public Long saveClubRecruitmentDraft(Long clubId, ClubRecruitmentRequestDTO recruitment) {
+        return 0L;
+    }
+
+    private void checkAuthorizationByClubId(Long clubId) {
+        // 클럽의 이름만 조회
+        String clubName = clubRepository.findClubNameById(clubId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
+
+        jwtTokenProvider.isAccessible(clubName);
     }
 }

--- a/src/main/java/kr/hanjari/backend/service/club/impl/ClubCommandServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/club/impl/ClubCommandServiceImpl.java
@@ -138,7 +138,7 @@ public class ClubCommandServiceImpl implements ClubCommandService {
 
         // Introduction 내용 업데이트
         introduction.updateIntroduction(clubIntroductionDTO.introduction(),
-                clubIntroductionDTO.activities(), clubIntroductionDTO.recruitment());
+                clubIntroductionDTO.activity(), clubIntroductionDTO.recruitment());
 
         // 저장
         Introduction saved = introductionRepository.save(introduction);
@@ -164,7 +164,7 @@ public class ClubCommandServiceImpl implements ClubCommandService {
 
         // IntroductionDraft 내용 업데이트
         introductionDraft.updateIntroduction(clubIntroductionDTO.introduction(),
-                clubIntroductionDTO.activities(), clubIntroductionDTO.recruitment());
+                clubIntroductionDTO.activity(), clubIntroductionDTO.recruitment());
 
         // 저장
         IntroductionDraft saved = introductionDraftRepository.save(introductionDraft);

--- a/src/main/java/kr/hanjari/backend/service/club/impl/ClubCommandServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/club/impl/ClubCommandServiceImpl.java
@@ -176,26 +176,36 @@ public class ClubCommandServiceImpl implements ClubCommandService {
 
     @Override
     public Long saveClubRecruitment(Long clubId, ClubRecruitmentRequestDTO clubRecruitmentDTO) {
-
-        if (!clubRepository.existsById(clubId)) {
+        if (!clubRepository.existsById(clubId))
             throw new GeneralException(ErrorStatus._CLUB_NOT_FOUND);
-        }
 
         Recruitment recruitment = recruitmentRepository.findById(clubId)
                 .orElseGet(() -> Recruitment.builder().clubId(clubId).build());
 
-        // 클럽의 이름만 조회
         checkAuthorizationByClubId(clubId);
-
         recruitment.updateRecruitment(clubRecruitmentDTO);
-
         Recruitment save = recruitmentRepository.save(recruitment);
+
+        if (recruitmentDraftRepository.existsByClubId(clubId))
+            recruitmentDraftRepository.removeByClubId(clubId);
 
         return save.getClubId();
     }
+
     @Override
-    public Long saveClubRecruitmentDraft(Long clubId, ClubRecruitmentRequestDTO recruitment) {
-        return 0L;
+    public Long saveClubRecruitmentDraft(Long clubId, ClubRecruitmentRequestDTO clubRecruitmentDTO) {
+        if (!clubRepository.existsById(clubId))
+            throw new GeneralException(ErrorStatus._CLUB_NOT_FOUND);
+
+
+        RecruitmentDraft recruitment = recruitmentDraftRepository.findById(clubId)
+                .orElseGet(() -> RecruitmentDraft.builder().clubId(clubId).build());
+
+        checkAuthorizationByClubId(clubId);
+        recruitment.updateRecruitment(clubRecruitmentDTO);
+        RecruitmentDraft save = recruitmentDraftRepository.save(recruitment);
+
+        return save.getClubId();
     }
 
     private void checkAuthorizationByClubId(Long clubId) {

--- a/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
@@ -6,6 +6,7 @@ import kr.hanjari.backend.domain.Club;
 import kr.hanjari.backend.domain.Introduction;
 import kr.hanjari.backend.domain.Recruitment;
 import kr.hanjari.backend.domain.Schedule;
+import kr.hanjari.backend.domain.draft.IntroductionDraft;
 import kr.hanjari.backend.domain.enums.ClubCategory;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 import kr.hanjari.backend.domain.enums.SortBy;
@@ -15,8 +16,11 @@ import kr.hanjari.backend.repository.ClubRepository;
 import kr.hanjari.backend.repository.IntroductionRepository;
 import kr.hanjari.backend.repository.RecruitmentRepository;
 import kr.hanjari.backend.repository.ScheduleRepository;
+import kr.hanjari.backend.repository.draft.IntroductionDraftRepository;
+import kr.hanjari.backend.repository.draft.RecruitmentDraftRepository;
 import kr.hanjari.backend.repository.specification.ClubSpecifications;
 import kr.hanjari.backend.service.club.ClubQueryService;
+import kr.hanjari.backend.web.dto.club.response.ClubIntroductionDraftResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubIntroductionResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubRecruitmentResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubResponseDTO;
@@ -41,6 +45,9 @@ public class ClubQueryServiceImpl implements ClubQueryService {
     private final IntroductionRepository introductionRepository;
     private final RecruitmentRepository recruitmentRepository;
     private final ScheduleRepository scheduleRepository;
+
+    private final IntroductionDraftRepository introductionDraftRepository;
+    private final RecruitmentDraftRepository recruitmentDraftRepository;
 
 
     @Override
@@ -93,6 +100,18 @@ public class ClubQueryServiceImpl implements ClubQueryService {
     }
 
     @Override
+    public ClubIntroductionDraftResponseDTO findClubIntroductionDraft(Long clubId) {
+        if (!clubRepository.existsById(clubId)) {
+            throw new GeneralException(ErrorStatus._CLUB_NOT_FOUND);
+        }
+
+        IntroductionDraft introduction = introductionDraftRepository.findByClubId(clubId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._INTRODUCTION_DRAFT_NOT_FOUND));
+        
+        return ClubIntroductionDraftResponseDTO.of(introduction);
+    }
+
+    @Override
     public ClubRecruitmentResponseDTO findClubRecruitment(Long clubId) {
 
         Club club = clubRepository.findById(clubId).orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
@@ -102,5 +121,10 @@ public class ClubQueryServiceImpl implements ClubQueryService {
 
 
         return ClubRecruitmentResponseDTO.of(recruitment, club);
+    }
+
+    @Override
+    public ClubRecruitmentResponseDTO findClubRecruitmentDraft(Long clubId) {
+        return null;
     }
 }

--- a/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
@@ -7,6 +7,7 @@ import kr.hanjari.backend.domain.Introduction;
 import kr.hanjari.backend.domain.Recruitment;
 import kr.hanjari.backend.domain.Schedule;
 import kr.hanjari.backend.domain.draft.IntroductionDraft;
+import kr.hanjari.backend.domain.draft.RecruitmentDraft;
 import kr.hanjari.backend.domain.enums.ClubCategory;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 import kr.hanjari.backend.domain.enums.SortBy;
@@ -22,6 +23,7 @@ import kr.hanjari.backend.repository.specification.ClubSpecifications;
 import kr.hanjari.backend.service.club.ClubQueryService;
 import kr.hanjari.backend.web.dto.club.response.ClubIntroductionDraftResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubIntroductionResponseDTO;
+import kr.hanjari.backend.web.dto.club.response.ClubRecruitmentDraftResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubRecruitmentResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubScheduleResponseDTO;
@@ -117,14 +119,18 @@ public class ClubQueryServiceImpl implements ClubQueryService {
         Club club = clubRepository.findById(clubId).orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
 
         Recruitment recruitment = recruitmentRepository.findByClubId(clubId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus._INTRODUCTION_NOT_FOUND));
-
+                .orElseThrow(() -> new GeneralException(ErrorStatus._RECRUITMENT_NOT_FOUND));
 
         return ClubRecruitmentResponseDTO.of(recruitment, club);
     }
 
     @Override
-    public ClubRecruitmentResponseDTO findClubRecruitmentDraft(Long clubId) {
-        return null;
+    public ClubRecruitmentDraftResponseDTO findClubRecruitmentDraft(Long clubId) {
+        clubRepository.findById(clubId).orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
+
+        RecruitmentDraft recruitment = recruitmentDraftRepository.findByClubId(clubId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._RECRUITMENT_DRAFT_NOT_FOUND));
+
+        return ClubRecruitmentDraftResponseDTO.of(recruitment);
     }
 }

--- a/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
+++ b/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
@@ -321,6 +321,6 @@ public class ClubController {
     public ApiResponse<?> postClubRecruitmentDraft(
             @PathVariable Long clubId,
             @RequestBody ClubRecruitmentRequestDTO clubRecruitmentDTO) {
-        return ApiResponse.onSuccess();
+        return ApiResponse.onSuccess(clubCommandService.saveClubRecruitmentDraft(clubId, clubRecruitmentDTO));
     }
 }

--- a/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
+++ b/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
@@ -237,6 +237,35 @@ public class ClubController {
         return ApiResponse.onSuccess(clubCommandService.saveClubIntroduction(clubId, clubIntroductionDTO));
     }
 
+    @Tag(name = "동아리 소개 - 소개글", description = "동아리 소개 관련 API")
+    @Operation(summary = "[동아리 소개] 임시 저장된 동아리 소개 조회", description = """
+            ## 임시 저장 된 동아리 소개글을 조회합니다.
+            - **clubId**: 조회할 동아리의 ID
+            """)
+    @GetMapping("/{clubId}/introduction/draft")
+    public ApiResponse<ClubIntroductionResponseDTO> getClubIntroductionDraft(@PathVariable Long clubId) {
+        return ApiResponse.onSuccess();
+    }
+
+    @Tag(name = "동아리 소개 - 소개글", description = "동아리 소개 관련 API")
+    @Operation(summary = "[동아리 소개] 동아리 소개 임시 저장", description = """
+            ## 동아리 소개글을 임시 저장 합니다. 
+            ### Path Variable
+            - **clubId**: 입력할 동아리의 ID  \n
+            
+            ### Request Body
+            - **introduction**: 동아리 소개 (string, 500자 미만) \n
+            - **activity**: 활동 내용 (string, 1000자 미만) \n
+            - **recruitment**: 원하는 동아리 원 설명 (string, 500자 미만) \n
+            """)
+    @PostMapping("/{clubId}/introduction/draft")
+    public ApiResponse<?> postClubIntroductionDraft(
+            @PathVariable Long clubId,
+            @RequestBody ClubIntroductionRequestDTO clubIntroductionDTO) {
+        return ApiResponse.onSuccess();
+    }
+
+
     /*----------------------------- 동아리 모집 안내 ------------------------------*/
     @Tag(name = "동아리 모집 안내", description = "동아리 모집 안내 관련 API")
     @Operation(summary = "[동아리 모집 안내] 동아리 모집 안내 조회", description = """
@@ -264,5 +293,33 @@ public class ClubController {
             @PathVariable Long clubId,
             @RequestBody ClubRecruitmentRequestDTO clubRecruitmentDTO) {
         return ApiResponse.onSuccess(clubCommandService.saveClubRecruitment(clubId, clubRecruitmentDTO));
+    }
+
+    @Tag(name = "동아리 모집 안내", description = "동아리 모집 안내 관련 API")
+    @Operation(summary = "[동아리 모집 안내] 임시 저장 된 동아리 모집 안내 조회", description = """
+            ## 임시 저장 된 동아리 모집 안내를 조회합니다.
+            - **clubId**: 조회할 동아리의 ID
+            """)
+    @GetMapping("/{clubId}/recruitment/draft")
+    public ApiResponse<ClubRecruitmentResponseDTO> getClubRecruitmentDraft(@PathVariable Long clubId) {
+        return ApiResponse.onSuccess();
+    }
+
+    @Tag(name = "동아리 모집 안내", description = "동아리 모집 안내 관련 API")
+    @Operation(summary = "[동아리 모집 안내] 동아리 모집 안내 임시 저장", description = """
+            ## 동아리 모집 안내를 임시저장 합니다.
+            ### Path Variable
+            - **clubId**: 입력할 동아리의 ID  \n
+            
+            ### Request Body
+            - **due**: 동아리 모집 기간 (string, 500자 미만) \n
+            - **notice**: 유의사항 (string, 500자 미만) \n
+            - **etc**: 기타 동아리 모집 안내 (string, 500자 미만) \n
+            """)
+    @PostMapping("/{clubId}/recruitment/draft")
+    public ApiResponse<?> postClubRecruitmentDraft(
+            @PathVariable Long clubId,
+            @RequestBody ClubRecruitmentRequestDTO clubRecruitmentDTO) {
+        return ApiResponse.onSuccess();
     }
 }

--- a/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
+++ b/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
@@ -14,6 +14,7 @@ import kr.hanjari.backend.web.dto.club.request.ClubIntroductionRequestDTO;
 import kr.hanjari.backend.web.dto.club.request.ClubRecruitmentRequestDTO;
 import kr.hanjari.backend.web.dto.club.request.ClubScheduleRequestDTO;
 import kr.hanjari.backend.web.dto.club.request.CommonClubDTO;
+import kr.hanjari.backend.web.dto.club.response.ClubIntroductionDraftResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubRecruitmentResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubIntroductionResponseDTO;
@@ -243,8 +244,8 @@ public class ClubController {
             - **clubId**: 조회할 동아리의 ID
             """)
     @GetMapping("/{clubId}/introduction/draft")
-    public ApiResponse<ClubIntroductionResponseDTO> getClubIntroductionDraft(@PathVariable Long clubId) {
-        return ApiResponse.onSuccess();
+    public ApiResponse<ClubIntroductionDraftResponseDTO> getClubIntroductionDraft(@PathVariable Long clubId) {
+        return ApiResponse.onSuccess(clubQueryService.findClubIntroductionDraft(clubId));
     }
 
     @Tag(name = "동아리 소개 - 소개글", description = "동아리 소개 관련 API")
@@ -262,7 +263,7 @@ public class ClubController {
     public ApiResponse<?> postClubIntroductionDraft(
             @PathVariable Long clubId,
             @RequestBody ClubIntroductionRequestDTO clubIntroductionDTO) {
-        return ApiResponse.onSuccess();
+        return ApiResponse.onSuccess(clubCommandService.saveClubIntroductionDraft(clubId, clubIntroductionDTO));
     }
 
 

--- a/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
+++ b/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
@@ -15,6 +15,7 @@ import kr.hanjari.backend.web.dto.club.request.ClubRecruitmentRequestDTO;
 import kr.hanjari.backend.web.dto.club.request.ClubScheduleRequestDTO;
 import kr.hanjari.backend.web.dto.club.request.CommonClubDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubIntroductionDraftResponseDTO;
+import kr.hanjari.backend.web.dto.club.response.ClubRecruitmentDraftResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubRecruitmentResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubIntroductionResponseDTO;
@@ -302,8 +303,8 @@ public class ClubController {
             - **clubId**: 조회할 동아리의 ID
             """)
     @GetMapping("/{clubId}/recruitment/draft")
-    public ApiResponse<ClubRecruitmentResponseDTO> getClubRecruitmentDraft(@PathVariable Long clubId) {
-        return ApiResponse.onSuccess();
+    public ApiResponse<ClubRecruitmentDraftResponseDTO> getClubRecruitmentDraft(@PathVariable Long clubId) {
+        return ApiResponse.onSuccess(clubQueryService.findClubRecruitmentDraft(clubId));
     }
 
     @Tag(name = "동아리 모집 안내", description = "동아리 모집 안내 관련 API")

--- a/src/main/java/kr/hanjari/backend/web/dto/club/request/ClubIntroductionRequestDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/request/ClubIntroductionRequestDTO.java
@@ -2,7 +2,7 @@ package kr.hanjari.backend.web.dto.club.request;
 
 public record ClubIntroductionRequestDTO(
         String introduction,
-        String activities,
+        String activity,
         String recruitment
 ) {
 }

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubIntroductionDraftResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubIntroductionDraftResponseDTO.java
@@ -1,0 +1,17 @@
+package kr.hanjari.backend.web.dto.club.response;
+
+import kr.hanjari.backend.domain.draft.IntroductionDraft;
+
+public record ClubIntroductionDraftResponseDTO(
+        String introduction,
+        String activity,
+        String recruitment) {
+    public static ClubIntroductionDraftResponseDTO of(IntroductionDraft introductionDraft) {
+        return new ClubIntroductionDraftResponseDTO(
+                introductionDraft.getContent1(),
+                introductionDraft.getContent2(),
+                introductionDraft.getContent3()
+        );
+    }
+
+}

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubRecruitmentDraftResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubRecruitmentDraftResponseDTO.java
@@ -1,0 +1,19 @@
+package kr.hanjari.backend.web.dto.club.response;
+
+import kr.hanjari.backend.domain.Recruitment;
+import kr.hanjari.backend.domain.draft.RecruitmentDraft;
+
+public record ClubRecruitmentDraftResponseDTO(
+        String due,
+        String notice,
+        String etc )
+{
+    public static ClubRecruitmentDraftResponseDTO of(RecruitmentDraft recruitment) {
+        return new ClubRecruitmentDraftResponseDTO(
+                recruitment.getContent1(),
+                recruitment.getContent2(),
+                recruitment.getContent3()
+        );
+    }
+
+}


### PR DESCRIPTION
## 💻 작업사항

- 동아리 소개글, 모집 안내 임시저장 API 구현 완료, 자세한 구현 내용은 아래와 같습니다. 
1. 임시 저장을 위한 테이블 생성 
2. 임시 저장 엔티티 생성 및 조회 API 구현 
3. 임시 저장 조회 API의 경우에는 JWT 기반 접근 유무 검증 로직 추가 (자신의 동아리만 조회 가능, 다른 조회 API와 차이점)

## 💡 작성한 이슈 외에 작업한 사항

- 중복되는 JWT 관련 로직 메서드 추출 

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
