### PR TITLE
♻ [REFACTOR] 관리자 네이밍 통일 및 누락된 Enum 추가 

### DIFF
--- a/src/main/java/kr/hanjari/backend/config/SecurityConfig.java
+++ b/src/main/java/kr/hanjari/backend/config/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
             "/api/club/service-admin", "/api/club/service-admin/**"
     };
 
-    private final String[] ADMIN_URL = {
+    private final String[] UNION_ADMIN_URL = {
             "/api/announcements/union-admin", "/api/announcements/union-admin/**",
             "/api/documents/union-admin", "/api/documents/union-admin/**"
     };
@@ -55,7 +55,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         authorizeRequests -> authorizeRequests
                                 .requestMatchers(SERVICE_ADMIN_URL).hasRole("SERVICE_ADMIN")
-                                .requestMatchers(ADMIN_URL).hasRole("UNION_ADMIN")
+                                .requestMatchers(UNION_ADMIN_URL).hasRole("UNION_ADMIN")
                                 .requestMatchers(CLUB_ADMIN_URL).hasRole("CLUB_ADMIN")
                                 .anyRequest().permitAll()
                 );

--- a/src/main/java/kr/hanjari/backend/config/SecurityConfig.java
+++ b/src/main/java/kr/hanjari/backend/config/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         authorizeRequests -> authorizeRequests
                                 .requestMatchers(SERVICE_ADMIN_URL).hasRole("SERVICE_ADMIN")
-                                .requestMatchers(ADMIN_URL).hasRole("ADMIN")
+                                .requestMatchers(ADMIN_URL).hasRole("UNION_ADMIN")
                                 .requestMatchers(CLUB_ADMIN_URL).hasRole("CLUB_ADMIN")
                                 .anyRequest().permitAll()
                 );

--- a/src/main/java/kr/hanjari/backend/config/SecurityConfig.java
+++ b/src/main/java/kr/hanjari/backend/config/SecurityConfig.java
@@ -25,8 +25,8 @@ public class SecurityConfig {
     };
 
     private final String[] ADMIN_URL = {
-            "/api/announcements/admin", "/api/announcements/admin/**",
-            "/api/documents/admin", "/api/documents/admin/**"
+            "/api/announcements/union-admin", "/api/announcements/union-admin/**",
+            "/api/documents/union-admin", "/api/documents/union-admin/**"
     };
 
     private final String[] CLUB_ADMIN_URL = {

--- a/src/main/java/kr/hanjari/backend/domain/enums/ClubCategory.java
+++ b/src/main/java/kr/hanjari/backend/domain/enums/ClubCategory.java
@@ -1,5 +1,10 @@
 package kr.hanjari.backend.domain.enums;
 
 public enum ClubCategory {
-    SPORTS, ART
+    VOLUNTEER,    // 봉사
+    ART,          // 예술
+    SPORTS,       // 체육
+    RELIGION,     // 종교
+    ACADEMIC,     // 학술교양
+    UNION         // 연합동아리
 }

--- a/src/main/java/kr/hanjari/backend/domain/enums/Role.java
+++ b/src/main/java/kr/hanjari/backend/domain/enums/Role.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 public enum Role {
 
     SERVICE_ADMIN("SERVICE_ADMIN"),
-    ADMIN("ADMIN"),
+    UNION_ADMIN("ADMIN"),
     CLUB_ADMIN("CLUB_ADMIN");
 
     private final String role;

--- a/src/main/java/kr/hanjari/backend/domain/enums/Role.java
+++ b/src/main/java/kr/hanjari/backend/domain/enums/Role.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 public enum Role {
 
     SERVICE_ADMIN("SERVICE_ADMIN"),
-    UNION_ADMIN("ADMIN"),
+    UNION_ADMIN("UNION_ADMIN"),
     CLUB_ADMIN("CLUB_ADMIN");
 
     private final String role;

--- a/src/main/java/kr/hanjari/backend/security/token/JwtUtil.java
+++ b/src/main/java/kr/hanjari/backend/security/token/JwtUtil.java
@@ -38,7 +38,7 @@ public class JwtUtil {
     private final StringRedisTemplate redisTemplate;
 
     public String createAdminToken() {
-        return createToken(0L, Role.ADMIN.getRole());
+        return createToken(0L, Role.UNION_ADMIN.getRole());
     }
 
     public String createServiceAdminToken() {

--- a/src/main/java/kr/hanjari/backend/web/controller/AnnouncementController.java
+++ b/src/main/java/kr/hanjari/backend/web/controller/AnnouncementController.java
@@ -34,7 +34,7 @@ public class AnnouncementController {
         - **생성된 공지사항의 ID**
         """
     )
-    @PostMapping(value = "/admin", consumes = {"application/json", "multipart/form-data"})
+    @PostMapping(value = "/union-admin", consumes = {"application/json", "multipart/form-data"})
     public ApiResponse<Long> postNewAnnouncement(@RequestPart(name = "requestBody") CommonAnnouncementRequest requestBody,
                                                  @RequestPart(name = "thumbnail") MultipartFile thumbnail) {
         Long result = announcementService.createAnnouncement(requestBody, thumbnail);
@@ -78,7 +78,7 @@ public class AnnouncementController {
         - **썸네일 이미지 (필수 X, 이미지도 수정하는 경우에만 입력)**
         """
     )
-    @PatchMapping(value = "/admin/{announcementId}", consumes = {"application/json", "multipart/form-data"})
+    @PatchMapping(value = "/union-admin/{announcementId}", consumes = {"application/json", "multipart/form-data"})
     public ApiResponse<Void> updateAnnouncement(@PathVariable Long announcementId,
                                                 @RequestPart(name = "requestBody") CommonAnnouncementRequest requestBody,
                                                 @RequestPart(name = "thumbnail", required = false) MultipartFile thumbnail) {
@@ -94,7 +94,7 @@ public class AnnouncementController {
         #### 📌 announcementId: 삭제할 공지사항의 ID
         """
     )
-    @DeleteMapping("/admin/{announcementId}")
+    @DeleteMapping("/union-admin/{announcementId}")
     public ApiResponse<Void> deleteAnnouncement(@PathVariable Long announcementId) {
 
         announcementService.deleteAnnouncement(announcementId);

--- a/src/main/java/kr/hanjari/backend/web/controller/AuthController.java
+++ b/src/main/java/kr/hanjari/backend/web/controller/AuthController.java
@@ -11,6 +11,8 @@ import kr.hanjari.backend.web.dto.auth.request.LoginRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+
+@CrossOrigin
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor

--- a/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
+++ b/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
@@ -327,6 +327,7 @@ public class ClubController {
         return ApiResponse.onSuccess(clubCommandService.saveClubRecruitmentDraft(clubId, clubRecruitmentDTO));
     }
 
+    @Tag(name = "동아리 인증 코드", description = "동아리 인증 코드 발급 API")
     @Operation(summary = "[인증] 동아리 인증 코드 재발급", description = """
             ## 동아리의 인증 코드를 재발급합니다(기존 인증 코드 대체).
             - **clubId**: 동아리 ID


### PR DESCRIPTION
## 💻 작업사항

- 총동연 관리자 명 `admin`에서 `union-admin`으로 변경 
- 누락된 동아리 카테고리 추가 : `VOLUNTEER // 봉사 , RELIGION // 종교 ,  ACADEMIC  // 학술 교양 ,  UNION // 연합동아리`   

## 💡 작성한 이슈 외에 작업한 사항

- 동아리 인증 코드 API 명세서 태그 추가
- Auth API CORS 해결
## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
