### PR TITLE
:sparkles: [FEATURE] 동아리 대표 이미지 관련 API 구현

### DIFF
--- a/src/main/java/kr/hanjari/backend/domain/Club.java
+++ b/src/main/java/kr/hanjari/backend/domain/Club.java
@@ -75,7 +75,6 @@ public class Club extends BaseEntity {
     public void updateClubDetails(ClubDetailRequestDTO detail) {
         this.recruitmentStatus = detail.recruitmentStatus();
         this.leaderName = detail.leaderName();
-        this.leaderEmail = detail.leaderEmail();
         this.leaderPhone = detail.leaderPhone();
         this.membershipFee = detail. membershipFee();
         this.meetingSchedule = detail.activities();

--- a/src/main/java/kr/hanjari/backend/domain/Club.java
+++ b/src/main/java/kr/hanjari/backend/domain/Club.java
@@ -5,6 +5,7 @@ import kr.hanjari.backend.domain.common.BaseEntity;
 import kr.hanjari.backend.domain.enums.ClubCategory;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 import kr.hanjari.backend.web.dto.club.request.ClubDetailRequestDTO;
+import kr.hanjari.backend.web.dto.club.request.CommonClubDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -80,6 +81,14 @@ public class Club extends BaseEntity {
         this.meetingSchedule = detail.activities();
         this.snsUrl = detail.snsUrl();
         this.applicationUrl = detail.applicationUrl();
+    }
+
+    public void updateClubCommonInfo(CommonClubDTO commonInfo) {
+        this.name = commonInfo.clubName();
+        this.leaderEmail = commonInfo.leaderEmail();
+        this.category = ClubCategory.valueOf(commonInfo.category());
+        this.oneLiner = commonInfo.oneLiner();
+        this.briefIntroduction = commonInfo.briefIntroduction();
     }
 
     public void updateCode(String code) {

--- a/src/main/java/kr/hanjari/backend/domain/draft/ClubDetailDraft.java
+++ b/src/main/java/kr/hanjari/backend/domain/draft/ClubDetailDraft.java
@@ -25,6 +25,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class ClubDetailDraft  {
 
+    @Id
     @Column(name = "club_id")
     private Long clubId;
 
@@ -33,9 +34,6 @@ public class ClubDetailDraft  {
 
     @Column(name = "leader_name")
     String leaderName;
-
-    @Column(name = "leader_email")
-    String leaderEmail;
 
     @Column(name = "leader_phone")
     String leaderPhone;
@@ -55,7 +53,6 @@ public class ClubDetailDraft  {
     public void updateClubDetails(ClubDetailRequestDTO request) {
         this.recruitmentStatus = request.recruitmentStatus();
         this.leaderName = request.leaderName();
-        this.leaderEmail = request.leaderEmail();
         this.leaderPhone = request.leaderPhone();
         this.activities = request.activities();
         this.membershipFee = request.membershipFee();

--- a/src/main/java/kr/hanjari/backend/domain/draft/ClubDetailDraft.java
+++ b/src/main/java/kr/hanjari/backend/domain/draft/ClubDetailDraft.java
@@ -1,0 +1,65 @@
+package kr.hanjari.backend.domain.draft;
+
+import com.fasterxml.jackson.databind.ser.Serializers.Base;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import kr.hanjari.backend.domain.common.BaseEntity;
+import kr.hanjari.backend.domain.enums.RecruitmentStatus;
+import kr.hanjari.backend.web.dto.club.request.ClubDetailRequestDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ClubDetailDraft  {
+
+    @Column(name = "club_id")
+    private Long clubId;
+
+    @Enumerated(EnumType.STRING)
+    RecruitmentStatus recruitmentStatus;
+
+    @Column(name = "leader_name")
+    String leaderName;
+
+    @Column(name = "leader_email")
+    String leaderEmail;
+
+    @Column(name = "leader_phone")
+    String leaderPhone;
+
+    @Column(name = "activities")
+    String activities;
+
+    @Column(name = "membership_fee")
+    Integer membershipFee;
+
+    @Column(name = "sns_url")
+    String snsUrl;
+
+    @Column(name = "application_url")
+    String applicationUrl;
+
+    public void updateClubDetails(ClubDetailRequestDTO request) {
+        this.recruitmentStatus = request.recruitmentStatus();
+        this.leaderName = request.leaderName();
+        this.leaderEmail = request.leaderEmail();
+        this.leaderPhone = request.leaderPhone();
+        this.activities = request.activities();
+        this.membershipFee = request.membershipFee();
+        this.snsUrl = request.snsUrl();
+        this.applicationUrl = request.applicationUrl();
+    }
+}

--- a/src/main/java/kr/hanjari/backend/payload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/hanjari/backend/payload/code/status/ErrorStatus.java
@@ -28,6 +28,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 동아리 관련
     _CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUB404", "동아리를 찾을 수 없습니다."),
     _INVALID_CODE(HttpStatus.BAD_REQUEST, "CLUB400", "유효하지 않은 코드입니다."),
+    _CLUB_DETAIL_DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUB404", "임시 저장 된 동아리 상세 정보를 찾을 수 없습니다."),
 
     _SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "ACTIVITY404", "활동을 찾을 수 없습니다."),
     _SCHEDULE_IS_NOT_BELONG_TO_CLUB(HttpStatus.BAD_REQUEST, "ACTIVITY400", "해당 동아리에 속한 활동이 아닙니다."),

--- a/src/main/java/kr/hanjari/backend/repository/draft/ClubDetailDraftRepository.java
+++ b/src/main/java/kr/hanjari/backend/repository/draft/ClubDetailDraftRepository.java
@@ -1,0 +1,9 @@
+package kr.hanjari.backend.repository.draft;
+
+import kr.hanjari.backend.domain.draft.ClubDetailDraft;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ClubDetailDraftRepository extends JpaRepository<ClubDetailDraft, Long> {
+}

--- a/src/main/java/kr/hanjari/backend/service/club/ClubCommandService.java
+++ b/src/main/java/kr/hanjari/backend/service/club/ClubCommandService.java
@@ -1,5 +1,6 @@
 package kr.hanjari.backend.service.club;
 
+import kr.hanjari.backend.domain.Club;
 import kr.hanjari.backend.web.dto.club.request.*;
 import kr.hanjari.backend.web.dto.club.response.ScheduleResponseDTO;
 import org.springframework.web.multipart.MultipartFile;
@@ -12,6 +13,7 @@ public interface ClubCommandService {
 
     // 동아리 상세 정보
     Long saveClubDetail(Long clubId, ClubDetailRequestDTO clubDetailDTO);
+    Long updateClubDetail(Long clubId, CommonClubDTO request, MultipartFile file);
 
     // 동아리 월 별 일정
     ScheduleResponseDTO saveClubSchedule(Long clubId, ClubScheduleRequestDTO clubActivityDTO);

--- a/src/main/java/kr/hanjari/backend/service/club/ClubCommandService.java
+++ b/src/main/java/kr/hanjari/backend/service/club/ClubCommandService.java
@@ -14,6 +14,7 @@ public interface ClubCommandService {
     // 동아리 상세 정보
     Long saveClubDetail(Long clubId, ClubDetailRequestDTO clubDetailDTO);
     Long updateClubDetail(Long clubId, CommonClubDTO request, MultipartFile file);
+    Long saveClubDetailDraft(Long clubId, ClubDetailRequestDTO clubDetailDTO);
 
     // 동아리 월 별 일정
     ScheduleResponseDTO saveClubSchedule(Long clubId, ClubScheduleRequestDTO clubActivityDTO);

--- a/src/main/java/kr/hanjari/backend/service/club/ClubQueryService.java
+++ b/src/main/java/kr/hanjari/backend/service/club/ClubQueryService.java
@@ -4,6 +4,7 @@ package kr.hanjari.backend.service.club;
 import kr.hanjari.backend.domain.enums.ClubCategory;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 import kr.hanjari.backend.domain.enums.SortBy;
+import kr.hanjari.backend.web.dto.club.response.ClubDetailDraftResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubIntroductionDraftResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubIntroductionResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubRecruitmentDraftResponseDTO;
@@ -21,7 +22,7 @@ public interface ClubQueryService {
 
     // 동아리 상세 조회
     ClubResponseDTO findClubDetail(Long clubId);
-
+    ClubDetailDraftResponseDTO findClubDetailDraft(Long clubId);
 
     // 동아리 월 별 일정 조회
     ClubScheduleResponseDTO findAllClubActivities(Long clubId);

--- a/src/main/java/kr/hanjari/backend/service/club/ClubQueryService.java
+++ b/src/main/java/kr/hanjari/backend/service/club/ClubQueryService.java
@@ -22,6 +22,7 @@ public interface ClubQueryService {
     // 동아리 상세 조회
     ClubResponseDTO findClubDetail(Long clubId);
 
+
     // 동아리 월 별 일정 조회
     ClubScheduleResponseDTO findAllClubActivities(Long clubId);
 

--- a/src/main/java/kr/hanjari/backend/service/club/impl/ClubCommandServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/club/impl/ClubCommandServiceImpl.java
@@ -71,6 +71,10 @@ public class ClubCommandServiceImpl implements ClubCommandService {
         Club club = clubRepository.findById(clubId).orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
         club.updateClubDetails(clubDetailDTO);
         Club saved = clubRepository.save(club);
+
+        if (clubDetailDraftRepository.existsById(clubId)) {
+            clubDetailDraftRepository.deleteById(clubId);
+        }
         return saved.getId();
     }
 

--- a/src/main/java/kr/hanjari/backend/service/club/impl/ClubCommandServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/club/impl/ClubCommandServiceImpl.java
@@ -72,6 +72,19 @@ public class ClubCommandServiceImpl implements ClubCommandService {
     }
 
     @Override
+    public Long updateClubDetail(Long clubId, CommonClubDTO request, MultipartFile file) {
+        Club club = clubRepository.findById(clubId).orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
+        club.updateClubCommonInfo(request);
+
+        File imageFile = s3Service.uploadFile(file);
+        club.updateClubImage(imageFile);
+
+        Club saved = clubRepository.save(club);
+
+        return saved.getId();
+    }
+
+    @Override
     public ScheduleResponseDTO saveClubSchedule(Long clubId, ClubScheduleRequestDTO clubScheduleDTO) {
         Club club = clubRepository.findById(clubId).orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
 

--- a/src/main/java/kr/hanjari/backend/service/club/impl/ClubCommandServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/club/impl/ClubCommandServiceImpl.java
@@ -2,11 +2,13 @@ package kr.hanjari.backend.service.club.impl;
 
 
 import kr.hanjari.backend.domain.*;
+import kr.hanjari.backend.domain.draft.ClubDetailDraft;
 import kr.hanjari.backend.domain.draft.IntroductionDraft;
 import kr.hanjari.backend.domain.draft.RecruitmentDraft;
 import kr.hanjari.backend.payload.code.status.ErrorStatus;
 import kr.hanjari.backend.payload.exception.GeneralException;
 import kr.hanjari.backend.repository.*;
+import kr.hanjari.backend.repository.draft.ClubDetailDraftRepository;
 import kr.hanjari.backend.repository.draft.IntroductionDraftRepository;
 import kr.hanjari.backend.repository.draft.RecruitmentDraftRepository;
 import kr.hanjari.backend.security.token.JwtTokenProvider;
@@ -34,6 +36,7 @@ public class ClubCommandServiceImpl implements ClubCommandService {
 
     private final IntroductionDraftRepository introductionDraftRepository;
     private final RecruitmentDraftRepository recruitmentDraftRepository;
+    private final ClubDetailDraftRepository clubDetailDraftRepository;
 
     private final S3Service s3Service;
 
@@ -82,6 +85,22 @@ public class ClubCommandServiceImpl implements ClubCommandService {
         Club saved = clubRepository.save(club);
 
         return saved.getId();
+    }
+
+    @Override
+    public Long saveClubDetailDraft(Long clubId, ClubDetailRequestDTO clubDetailDTO) {
+        if (!clubRepository.existsById(clubId)) {
+            throw new GeneralException(ErrorStatus._CLUB_NOT_FOUND);
+        }
+
+        ClubDetailDraft clubDetailDraft = clubDetailDraftRepository.findById(clubId)
+                .orElseGet(() -> ClubDetailDraft.builder().clubId(clubId).build());
+
+        clubDetailDraft.updateClubDetails(clubDetailDTO);
+
+        ClubDetailDraft saved = clubDetailDraftRepository.save(clubDetailDraft);
+
+        return saved.getClubId();
     }
 
     @Override

--- a/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
@@ -6,6 +6,7 @@ import kr.hanjari.backend.domain.Club;
 import kr.hanjari.backend.domain.Introduction;
 import kr.hanjari.backend.domain.Recruitment;
 import kr.hanjari.backend.domain.Schedule;
+import kr.hanjari.backend.domain.draft.ClubDetailDraft;
 import kr.hanjari.backend.domain.draft.IntroductionDraft;
 import kr.hanjari.backend.domain.draft.RecruitmentDraft;
 import kr.hanjari.backend.domain.enums.ClubCategory;
@@ -17,12 +18,14 @@ import kr.hanjari.backend.repository.ClubRepository;
 import kr.hanjari.backend.repository.IntroductionRepository;
 import kr.hanjari.backend.repository.RecruitmentRepository;
 import kr.hanjari.backend.repository.ScheduleRepository;
+import kr.hanjari.backend.repository.draft.ClubDetailDraftRepository;
 import kr.hanjari.backend.repository.draft.IntroductionDraftRepository;
 import kr.hanjari.backend.repository.draft.RecruitmentDraftRepository;
 import kr.hanjari.backend.repository.specification.ClubSpecifications;
 import kr.hanjari.backend.security.token.JwtTokenProvider;
 import kr.hanjari.backend.service.club.ClubQueryService;
 import kr.hanjari.backend.service.s3.S3Service;
+import kr.hanjari.backend.web.dto.club.response.ClubDetailDraftResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubIntroductionDraftResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubIntroductionResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubRecruitmentDraftResponseDTO;
@@ -52,6 +55,7 @@ public class ClubQueryServiceImpl implements ClubQueryService {
 
     private final IntroductionDraftRepository introductionDraftRepository;
     private final RecruitmentDraftRepository recruitmentDraftRepository;
+    private final ClubDetailDraftRepository clubDetailDraftRepository;
 
     private final S3Service s3Service;
 
@@ -82,6 +86,14 @@ public class ClubQueryServiceImpl implements ClubQueryService {
         Club club = clubRepository.findById(clubId).orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
 
         return ClubResponseDTO.of(club, s3Service.getDownloadUrl(club.getImageFile().getId()));
+    }
+
+    @Override
+    public ClubDetailDraftResponseDTO findClubDetailDraft(Long clubId) {
+        ClubDetailDraft clubDetailDraft = clubDetailDraftRepository.findById(clubId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_DETAIL_DRAFT_NOT_FOUND));
+
+        return ClubDetailDraftResponseDTO.of(clubDetailDraft);
     }
 
     @Override

--- a/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
+++ b/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
@@ -150,6 +150,37 @@ public class ClubController {
             @RequestBody ClubDetailRequestDTO clubDetailDTO) {
         return ApiResponse.onSuccess(clubCommandService.saveClubDetail(clubId, clubDetailDTO));
     }
+    @Tag(name = "동아리 상세", description = "동아리 상세 정보 API")
+    @Operation(summary = "[동아리 상세] 임시 저장된 동아리 상세 정보 조회", description = """
+            ## 동아리 상세 정보를 조회합니다.
+            - **clubId**: 조회할 동아리의 ID
+            """)
+    @GetMapping("/{clubId}/draft")
+    public ApiResponse<ClubResponseDTO> getSpecificClubDraft(@PathVariable Long clubId) {
+        return ApiResponse.onSuccess(clubQueryService.findClubDetail(clubId));
+    }
+
+    @Tag(name = "동아리 상세", description = "동아리 상세 정보 API")
+    @Operation(summary = "[동아리 상세] 동아리 상세 정보 임시저장", description = """
+            ## 동아리 상세 정보를 임시저장합니다.
+            ### Path Variable
+            - **clubId**: 입력할 동아리의 ID  \n
+            
+            ### Request Body
+            - **recruitmentStatus**: 동아리 모집 상태 (enum, {UPCOMING, OPEN, CLOSED}) \n
+            - **leaderName**: 동아리 대표자 이름 (string) \n
+            - **leaderEmail**: 동아리 대표자 이메일 (string) \n
+            - **leaderPhone**: 동아리 대표자 연락처 (string) \n
+            - **activities**: 정기 모임 일정 (string) \n
+            - **snsUrl**: SNS 링크 (string) \n
+            - **applicationUrl**: 동아리 지원 링크 (string) \n
+            """)
+    @PostMapping("/club-admin/{clubId}/draft")
+    public ApiResponse<Long> postSpecificClubDraft(
+            @PathVariable Long clubId,
+            @RequestBody ClubDetailRequestDTO clubDetailDTO) {
+        return ApiResponse.onSuccess(clubCommandService.saveClubDetailDraft(clubId, clubDetailDTO));
+    }
 
     /*--------------------------- 동아리 월 별 일정 ---------------------------*/
     @Tag(name = "동아리 소개 - 월 별 일정", description = "동아리 소개 관련 API")

--- a/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
+++ b/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
@@ -86,9 +86,11 @@ public class ClubController {
             ### Multipart/form-data
             - **image**: 동아리 대표 사진
             """)
-    public void updateClubInfo(@RequestPart CommonClubDTO request,
-                               @RequestPart MultipartFile image) {
-        return;
+    @PostMapping("{clubId}/update")
+    public ApiResponse<Long> updateClubInfo(@RequestPart CommonClubDTO requestBody,
+                               @RequestPart MultipartFile image,
+                               @PathVariable Long clubId) {
+        return ApiResponse.onSuccess(clubCommandService.updateClubDetail(clubId, requestBody, image));
     }
 
     /*------------------------ 동아리 조건 별 조회 ----------------------------*/

--- a/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
+++ b/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
@@ -15,6 +15,7 @@ import kr.hanjari.backend.web.dto.club.request.ClubIntroductionRequestDTO;
 import kr.hanjari.backend.web.dto.club.request.ClubRecruitmentRequestDTO;
 import kr.hanjari.backend.web.dto.club.request.ClubScheduleRequestDTO;
 import kr.hanjari.backend.web.dto.club.request.CommonClubDTO;
+import kr.hanjari.backend.web.dto.club.response.ClubDetailDraftResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubIntroductionDraftResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubRecruitmentDraftResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubRecruitmentResponseDTO;
@@ -138,9 +139,9 @@ public class ClubController {
             ### Request Body
             - **recruitmentStatus**: 동아리 모집 상태 (enum, {UPCOMING, OPEN, CLOSED}) \n
             - **leaderName**: 동아리 대표자 이름 (string) \n
-            - **leaderEmail**: 동아리 대표자 이메일 (string) \n
             - **leaderPhone**: 동아리 대표자 연락처 (string) \n
             - **activities**: 정기 모임 일정 (string) \n
+            - **membershipFee**: 회비 (integer) \n
             - **snsUrl**: SNS 링크 (string) \n
             - **applicationUrl**: 동아리 지원 링크 (string) \n
             """)
@@ -154,10 +155,11 @@ public class ClubController {
     @Operation(summary = "[동아리 상세] 임시 저장된 동아리 상세 정보 조회", description = """
             ## 동아리 상세 정보를 조회합니다.
             - **clubId**: 조회할 동아리의 ID
+            
             """)
     @GetMapping("/{clubId}/draft")
-    public ApiResponse<ClubResponseDTO> getSpecificClubDraft(@PathVariable Long clubId) {
-        return ApiResponse.onSuccess(clubQueryService.findClubDetail(clubId));
+    public ApiResponse<ClubDetailDraftResponseDTO> getSpecificClubDraft(@PathVariable Long clubId) {
+        return ApiResponse.onSuccess(clubQueryService.findClubDetailDraft(clubId));
     }
 
     @Tag(name = "동아리 상세", description = "동아리 상세 정보 API")
@@ -169,9 +171,9 @@ public class ClubController {
             ### Request Body
             - **recruitmentStatus**: 동아리 모집 상태 (enum, {UPCOMING, OPEN, CLOSED}) \n
             - **leaderName**: 동아리 대표자 이름 (string) \n
-            - **leaderEmail**: 동아리 대표자 이메일 (string) \n
             - **leaderPhone**: 동아리 대표자 연락처 (string) \n
             - **activities**: 정기 모임 일정 (string) \n
+            - **membershipFee**: 회비 (integer) \n
             - **snsUrl**: SNS 링크 (string) \n
             - **applicationUrl**: 동아리 지원 링크 (string) \n
             """)

--- a/src/main/java/kr/hanjari/backend/web/dto/club/request/ClubDetailRequestDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/request/ClubDetailRequestDTO.java
@@ -5,7 +5,6 @@ import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 public record ClubDetailRequestDTO(
         RecruitmentStatus recruitmentStatus,
         String leaderName,
-        String leaderEmail,
         String leaderPhone,
         String activities,
         Integer membershipFee,

--- a/src/main/java/kr/hanjari/backend/web/dto/club/request/CommonClubDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/request/CommonClubDTO.java
@@ -3,6 +3,7 @@ package kr.hanjari.backend.web.dto.club.request;
 import kr.hanjari.backend.domain.ClubRegistration;
 import kr.hanjari.backend.domain.enums.ClubCategory;
 
+
 public record CommonClubDTO(String clubName,
                             String leaderEmail,
                             String category,

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubDetailDraftResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubDetailDraftResponseDTO.java
@@ -1,0 +1,26 @@
+package kr.hanjari.backend.web.dto.club.response;
+
+import kr.hanjari.backend.domain.draft.ClubDetailDraft;
+import kr.hanjari.backend.domain.enums.RecruitmentStatus;
+
+public record ClubDetailDraftResponseDTO(
+        RecruitmentStatus recruitmentStatus,
+        String leaderName,
+        String leaderPhone,
+        String activities,
+        Integer membershipFee,
+        String snsUrl,
+        String applicationUrl
+)  {
+    public static ClubDetailDraftResponseDTO of(ClubDetailDraft clubDetailDraft) {
+        return new ClubDetailDraftResponseDTO(
+                clubDetailDraft.getRecruitmentStatus(),
+                clubDetailDraft.getLeaderName(),
+                clubDetailDraft.getLeaderPhone(),
+                clubDetailDraft.getActivities(),
+                clubDetailDraft.getMembershipFee(),
+                clubDetailDraft.getSnsUrl(),
+                clubDetailDraft.getApplicationUrl()
+        );
+    }
+}

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubIntroductionResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubIntroductionResponseDTO.java
@@ -9,14 +9,14 @@ public record ClubIntroductionResponseDTO(
         String activity,
         String recruitment
 ) {
-    public static ClubIntroductionResponseDTO of(Club club, Introduction introduction) {
+    public static ClubIntroductionResponseDTO of(Club club, Introduction introduction, String profileImageUrl) {
         if (introduction == null) {
             return new ClubIntroductionResponseDTO(
-                    ClubResponseDTO.of(club),
+                    ClubResponseDTO.of(club, profileImageUrl),
                     null, null, null);
         }
         return new ClubIntroductionResponseDTO(
-                ClubResponseDTO.of(club),
+                ClubResponseDTO.of(club, profileImageUrl),
                 introduction.getContent1(),
                 introduction.getContent2(),
                 introduction.getContent3()

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubRecruitmentResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubRecruitmentResponseDTO.java
@@ -9,14 +9,14 @@ public record ClubRecruitmentResponseDTO(
         String notice,
         String etc
 ) {
-    public static ClubRecruitmentResponseDTO of(Recruitment recruitment, Club club) {
+    public static ClubRecruitmentResponseDTO of(Recruitment recruitment, Club club, String profileImageUrl) {
         if (recruitment == null) {
             return new ClubRecruitmentResponseDTO(
-                    ClubResponseDTO.of(club),
+                    ClubResponseDTO.of(club, profileImageUrl),
                     null, null, null);
         }
         return new ClubRecruitmentResponseDTO(
-                ClubResponseDTO.of(club),
+                ClubResponseDTO.of(club, profileImageUrl),
                 recruitment.getContent1(),
                 recruitment.getContent2(),
                 recruitment.getContent3()

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubResponseDTO.java
@@ -10,7 +10,7 @@ public record ClubResponseDTO(
         String description,
         ClubCategory category,
         RecruitmentStatus recruitmentStatus,
-        //String profileImageUrl,
+        String profileImageUrl,
         String activities,
         String leaderName,
         String leaderEmail,
@@ -19,14 +19,14 @@ public record ClubResponseDTO(
         String snsUrl,
         String applicationUrl
 ) {
-    public static ClubResponseDTO of(Club club) {
+    public static ClubResponseDTO of(Club club, String profileImageUrl) {
         return new ClubResponseDTO(
                 club.getId(),
                 club.getName(),
                 club.getBriefIntroduction(),
                 club.getCategory(),
                 club.getRecruitmentStatus(),
-                //club.getImageFile().getFileKey(),
+                profileImageUrl,
                 club.getMeetingSchedule(),
                 club.getLeaderName(),
                 club.getLeaderEmail(),

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubSearchResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubSearchResponseDTO.java
@@ -1,6 +1,7 @@
 package kr.hanjari.backend.web.dto.club.response;
 
 import java.util.List;
+import java.util.stream.IntStream;
 import kr.hanjari.backend.domain.Club;
 import org.springframework.data.domain.Page;
 
@@ -8,10 +9,11 @@ public record ClubSearchResponseDTO(
         List<ClubResponseDTO> clubs,
         int totalElements
 ) {
-    public static ClubSearchResponseDTO of(Page<Club> clubs) {
-        return new ClubSearchResponseDTO(
-                clubs.map(ClubResponseDTO::of).getContent(),
-                clubs.getNumberOfElements()
-        );
+    public static ClubSearchResponseDTO of(Page<Club> clubs, List<String> profileImageUrls) {
+        List<ClubResponseDTO> clubResponseList = IntStream.range(0, clubs.getContent().size())
+                .mapToObj(i -> ClubResponseDTO.of(clubs.getContent().get(i), profileImageUrls.get(i)))
+                .toList();
+
+        return new ClubSearchResponseDTO(clubResponseList, (int) clubs.getTotalElements());
     }
 }


### PR DESCRIPTION
## 💻 작업사항

-  동아리 상세 정보 업데이트 API 구현
- 동아리 관련 정보 조회 시, 이미지 URL 응답 하도록 수정

## 💡 작성한 이슈 외에 작업한 사항

- 동아리 상세 임시 저장 API 구현

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
