### PR TITLE
✨ [FEAT] 동아리 월 별 일정 임시저장 API 구현 및 조회 응답 값 수정

### DIFF
--- a/src/main/java/kr/hanjari/backend/domain/Club.java
+++ b/src/main/java/kr/hanjari/backend/domain/Club.java
@@ -75,6 +75,7 @@ public class Club extends BaseEntity {
     public void updateClubDetails(ClubDetailRequestDTO detail) {
         this.recruitmentStatus = detail.recruitmentStatus();
         this.leaderName = detail.leaderName();
+        this.oneLiner = detail.oneLiner();
         this.leaderPhone = detail.leaderPhone();
         this.membershipFee = detail. membershipFee();
         this.meetingSchedule = detail.activities();

--- a/src/main/java/kr/hanjari/backend/domain/draft/ClubDetailDraft.java
+++ b/src/main/java/kr/hanjari/backend/domain/draft/ClubDetailDraft.java
@@ -29,6 +29,9 @@ public class ClubDetailDraft  {
     @Column(name = "club_id")
     private Long clubId;
 
+    @Column(name = "one_liner")
+    String oneLiner;
+
     @Enumerated(EnumType.STRING)
     RecruitmentStatus recruitmentStatus;
 
@@ -52,6 +55,7 @@ public class ClubDetailDraft  {
 
     public void updateClubDetails(ClubDetailRequestDTO request) {
         this.recruitmentStatus = request.recruitmentStatus();
+        this.oneLiner = request.oneLiner();
         this.leaderName = request.leaderName();
         this.leaderPhone = request.leaderPhone();
         this.activities = request.activities();

--- a/src/main/java/kr/hanjari/backend/domain/draft/ScheduleDraft.java
+++ b/src/main/java/kr/hanjari/backend/domain/draft/ScheduleDraft.java
@@ -1,0 +1,43 @@
+package kr.hanjari.backend.domain.draft;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import kr.hanjari.backend.domain.Club;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Builder
+@Table(name = "schedule_draft")
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScheduleDraft {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "club_id")
+    private Club club;
+
+    @Column(name = "month", nullable = false)
+    private Integer month;
+
+    @Column(name = "content")
+    private String content;
+
+    public void updateSchedule(Integer month, String content) {
+        this.month = month;
+        this.content = content;
+    }
+
+}

--- a/src/main/java/kr/hanjari/backend/repository/draft/ScheduleDraftRepository.java
+++ b/src/main/java/kr/hanjari/backend/repository/draft/ScheduleDraftRepository.java
@@ -1,0 +1,12 @@
+package kr.hanjari.backend.repository.draft;
+
+import java.util.List;
+import kr.hanjari.backend.domain.draft.ScheduleDraft;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScheduleDraftRepository extends JpaRepository<ScheduleDraft, Long> {
+    void deleteByClubId(Long clubId);
+    List<ScheduleDraft> findAllByClubIdOrderByMonth(Long clubId);
+}

--- a/src/main/java/kr/hanjari/backend/service/club/ClubCommandService.java
+++ b/src/main/java/kr/hanjari/backend/service/club/ClubCommandService.java
@@ -3,6 +3,8 @@ package kr.hanjari.backend.service.club;
 import kr.hanjari.backend.web.dto.club.request.*;
 import kr.hanjari.backend.web.dto.club.response.ScheduleListResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ScheduleResponseDTO;
+import kr.hanjari.backend.web.dto.club.response.draft.ClubScheduleDraftResponseDTO;
+import kr.hanjari.backend.web.dto.club.response.draft.ScheduleDraftResponseDTO;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface ClubCommandService {
@@ -18,7 +20,7 @@ public interface ClubCommandService {
 
     // 동아리 월 별 일정
     ScheduleListResponseDTO saveAndUpdateClubSchedule(Long clubId, ClubScheduleListRequestDTO clubActivityDTO);
-    //ScheduleResponseDTO updateClubSchedule(Long clubId, Long scheduleId, ClubScheduleRequestDTO clubActivityDTO);
+    ClubScheduleDraftResponseDTO saveAndUpdateClubScheduleDraft(Long clubId, ClubScheduleListRequestDTO clubActivityDTO);
     void deleteClubSchedule(Long clubId, Long scheduleId);
 
     // 동아리 소개

--- a/src/main/java/kr/hanjari/backend/service/club/ClubQueryService.java
+++ b/src/main/java/kr/hanjari/backend/service/club/ClubQueryService.java
@@ -4,14 +4,15 @@ package kr.hanjari.backend.service.club;
 import kr.hanjari.backend.domain.enums.ClubCategory;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 import kr.hanjari.backend.domain.enums.SortBy;
-import kr.hanjari.backend.web.dto.club.response.ClubDetailDraftResponseDTO;
-import kr.hanjari.backend.web.dto.club.response.ClubIntroductionDraftResponseDTO;
+import kr.hanjari.backend.web.dto.club.response.draft.ClubDetailDraftResponseDTO;
+import kr.hanjari.backend.web.dto.club.response.draft.ClubIntroductionDraftResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubIntroductionResponseDTO;
-import kr.hanjari.backend.web.dto.club.response.ClubRecruitmentDraftResponseDTO;
+import kr.hanjari.backend.web.dto.club.response.draft.ClubRecruitmentDraftResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubRecruitmentResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubScheduleResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubSearchResponseDTO;
+import kr.hanjari.backend.web.dto.club.response.draft.ClubScheduleDraftResponseDTO;
 
 public interface ClubQueryService {
 
@@ -26,6 +27,7 @@ public interface ClubQueryService {
 
     // 동아리 월 별 일정 조회
     ClubScheduleResponseDTO findAllClubActivities(Long clubId);
+    ClubScheduleDraftResponseDTO findAllClubActivitiesDraft(Long clubId);
 
     // 동아리 소개 조회
     ClubIntroductionResponseDTO findClubIntroduction(Long clubId);

--- a/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
@@ -139,11 +139,12 @@ public class ClubQueryServiceImpl implements ClubQueryService {
 
     @Override
     public ClubIntroductionDraftResponseDTO findClubIntroductionDraft(Long clubId) {
+        Club club = clubRepository.findById(clubId).orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
 
         IntroductionDraft introduction = introductionDraftRepository.findByClubId(clubId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._INTRODUCTION_DRAFT_NOT_FOUND));
         
-        return ClubIntroductionDraftResponseDTO.of(introduction);
+        return ClubIntroductionDraftResponseDTO.of(club, introduction, s3Service.getDownloadUrl(club.getImageFile().getId()));
     }
 
     @Override

--- a/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
@@ -160,11 +160,12 @@ public class ClubQueryServiceImpl implements ClubQueryService {
 
     @Override
     public ClubRecruitmentDraftResponseDTO findClubRecruitmentDraft(Long clubId) {
+        Club club = clubRepository.findById(clubId).orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
 
         RecruitmentDraft recruitment = recruitmentDraftRepository.findByClubId(clubId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._RECRUITMENT_DRAFT_NOT_FOUND));
 
-        return ClubRecruitmentDraftResponseDTO.of(recruitment);
+        return ClubRecruitmentDraftResponseDTO.of(club, recruitment, s3Service.getDownloadUrl(club.getImageFile().getId()));
     }
 
 }

--- a/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
@@ -9,6 +9,7 @@ import kr.hanjari.backend.domain.Schedule;
 import kr.hanjari.backend.domain.draft.ClubDetailDraft;
 import kr.hanjari.backend.domain.draft.IntroductionDraft;
 import kr.hanjari.backend.domain.draft.RecruitmentDraft;
+import kr.hanjari.backend.domain.draft.ScheduleDraft;
 import kr.hanjari.backend.domain.enums.ClubCategory;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 import kr.hanjari.backend.domain.enums.SortBy;
@@ -21,18 +22,19 @@ import kr.hanjari.backend.repository.ScheduleRepository;
 import kr.hanjari.backend.repository.draft.ClubDetailDraftRepository;
 import kr.hanjari.backend.repository.draft.IntroductionDraftRepository;
 import kr.hanjari.backend.repository.draft.RecruitmentDraftRepository;
+import kr.hanjari.backend.repository.draft.ScheduleDraftRepository;
 import kr.hanjari.backend.repository.specification.ClubSpecifications;
-import kr.hanjari.backend.security.token.JwtTokenProvider;
 import kr.hanjari.backend.service.club.ClubQueryService;
 import kr.hanjari.backend.service.s3.S3Service;
-import kr.hanjari.backend.web.dto.club.response.ClubDetailDraftResponseDTO;
-import kr.hanjari.backend.web.dto.club.response.ClubIntroductionDraftResponseDTO;
+import kr.hanjari.backend.web.dto.club.response.draft.ClubDetailDraftResponseDTO;
+import kr.hanjari.backend.web.dto.club.response.draft.ClubIntroductionDraftResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubIntroductionResponseDTO;
-import kr.hanjari.backend.web.dto.club.response.ClubRecruitmentDraftResponseDTO;
+import kr.hanjari.backend.web.dto.club.response.draft.ClubRecruitmentDraftResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubRecruitmentResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubScheduleResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubSearchResponseDTO;
+import kr.hanjari.backend.web.dto.club.response.draft.ClubScheduleDraftResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -56,6 +58,7 @@ public class ClubQueryServiceImpl implements ClubQueryService {
     private final IntroductionDraftRepository introductionDraftRepository;
     private final RecruitmentDraftRepository recruitmentDraftRepository;
     private final ClubDetailDraftRepository clubDetailDraftRepository;
+    private final ScheduleDraftRepository scheduleDraftRepository;
 
     private final S3Service s3Service;
 
@@ -106,6 +109,17 @@ public class ClubQueryServiceImpl implements ClubQueryService {
 
         return ClubScheduleResponseDTO.of(schedules);
     }
+
+    @Override
+    public ClubScheduleDraftResponseDTO findAllClubActivitiesDraft(Long clubId) {
+        if (!clubRepository.existsById(clubId)) {
+            throw new GeneralException(ErrorStatus._CLUB_NOT_FOUND);
+        }
+        List<ScheduleDraft> schedules = scheduleDraftRepository.findAllByClubIdOrderByMonth(clubId);
+
+        return ClubScheduleDraftResponseDTO.of(schedules);
+    }
+
 
     @Override
     public ClubIntroductionResponseDTO findClubIntroduction(Long clubId) {

--- a/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
@@ -93,10 +93,12 @@ public class ClubQueryServiceImpl implements ClubQueryService {
 
     @Override
     public ClubDetailDraftResponseDTO findClubDetailDraft(Long clubId) {
+        Club club = clubRepository.findById(clubId).orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
+
         ClubDetailDraft clubDetailDraft = clubDetailDraftRepository.findById(clubId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_DETAIL_DRAFT_NOT_FOUND));
 
-        return ClubDetailDraftResponseDTO.of(clubDetailDraft);
+        return ClubDetailDraftResponseDTO.of(clubDetailDraft, club, s3Service.getDownloadUrl(club.getImageFile().getId()));
     }
 
     @Override

--- a/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
+++ b/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
@@ -136,6 +136,7 @@ public class ClubController {
             - **clubId**: 입력할 동아리의 ID  \n
             
             ### Request Body
+            - **oneLiner**: 동아리 한줄 소개 (string) \n
             - **recruitmentStatus**: 동아리 모집 상태 (enum, {UPCOMING, OPEN, CLOSED}) \n
             - **leaderName**: 동아리 대표자 이름 (string) \n
             - **leaderPhone**: 동아리 대표자 연락처 (string) \n
@@ -168,6 +169,7 @@ public class ClubController {
             - **clubId**: 입력할 동아리의 ID  \n
             
             ### Request Body
+            - **oneLiner**: 동아리 한줄 소개 (string) \n
             - **recruitmentStatus**: 동아리 모집 상태 (enum, {UPCOMING, OPEN, CLOSED}) \n
             - **leaderName**: 동아리 대표자 이름 (string) \n
             - **leaderPhone**: 동아리 대표자 연락처 (string) \n

--- a/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
+++ b/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
@@ -13,16 +13,16 @@ import kr.hanjari.backend.web.dto.club.request.ClubDetailRequestDTO;
 import kr.hanjari.backend.web.dto.club.request.ClubIntroductionRequestDTO;
 import kr.hanjari.backend.web.dto.club.request.ClubRecruitmentRequestDTO;
 import kr.hanjari.backend.web.dto.club.request.ClubScheduleListRequestDTO;
-import kr.hanjari.backend.web.dto.club.request.ClubScheduleRequestDTO;
 import kr.hanjari.backend.web.dto.club.request.CommonClubDTO;
-import kr.hanjari.backend.web.dto.club.response.ClubDetailDraftResponseDTO;
-import kr.hanjari.backend.web.dto.club.response.ClubIntroductionDraftResponseDTO;
-import kr.hanjari.backend.web.dto.club.response.ClubRecruitmentDraftResponseDTO;
+import kr.hanjari.backend.web.dto.club.response.draft.ClubDetailDraftResponseDTO;
+import kr.hanjari.backend.web.dto.club.response.draft.ClubIntroductionDraftResponseDTO;
+import kr.hanjari.backend.web.dto.club.response.draft.ClubRecruitmentDraftResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubRecruitmentResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubIntroductionResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubScheduleResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.ClubSearchResponseDTO;
+import kr.hanjari.backend.web.dto.club.response.draft.ClubScheduleDraftResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -213,25 +213,6 @@ public class ClubController {
         return ApiResponse.onSuccess(clubCommandService.saveAndUpdateClubSchedule(clubId, clubActivityDTO));
     }
 
-//    @Tag(name = "동아리 소개 - 월 별 일정", description = "동아리 소개 관련 API")
-//    @Operation(summary = "[동아리 소개] 동아리 월 별 일정 수정", description = """
-//            ## 동아리 월 별 일정을 수정합니다.
-//            ### Path Variable
-//            - **clubId**: 입력할 동아리의 ID  \n
-//            - **scheduleId**: 수정할 활동의 ID  \n
-//
-//            ### Request Body
-//            - **month**: 변경 하고싶은 월 (어떤 월로 바꾸고 싶은지 입력) (integer) \n
-//            - **content**: 활동 내용 (string, 30자 미만) \n
-//            """)
-//    @PatchMapping("/club-admin/{clubId}/schedules/{scheduleId}")
-//    public ApiResponse<?> patchClubSchedules(
-//            @PathVariable Long clubId,
-//            @PathVariable Long scheduleId,
-//            @RequestBody ClubScheduleRequestDTO clubScheduleDTO) {
-//        return ApiResponse.onSuccess(clubCommandService.updateClubSchedule(clubId, scheduleId, clubScheduleDTO));
-//    }
-
     @Tag(name = "동아리 소개 - 월 별 일정", description = "동아리 소개 관련 API")
     @Operation(summary = "[동아리 소개] 동아리 월 별 일정 삭제", description = """
             ## 동아리 월 별 일정을 삭제합니다. 
@@ -246,6 +227,36 @@ public class ClubController {
         clubCommandService.deleteClubSchedule(clubId, scheduleId);
         return ApiResponse.onSuccess();
     }
+
+    @Tag(name = "동아리 소개 - 월 별 일정", description = "동아리 소개 관련 API")
+    @Operation(summary = "[동아리 소개] 임시 저장된 동아리 월 별 일정 조회", description = """
+            ## 임시 저장 된 동아리 월 별 일정을 조회합니다.
+            - **clubId**: 조회할 동아리의 ID
+            """)
+    @GetMapping("/club-admin/{clubId}/schedules/draft")
+    public ApiResponse<ClubScheduleDraftResponseDTO> getClubSchedulesDraft(@PathVariable Long clubId) {
+        return ApiResponse.onSuccess(clubQueryService.findAllClubActivitiesDraft(clubId));
+    }
+
+    @Tag(name = "동아리 소개 - 월 별 일정", description = "동아리 소개 관련 API")
+    @Operation(summary = "[동아리 소개] 동아리 월 별 일정 임시 저장", description = """
+            ## 동아리 월 별 일정을 임시 저장합니다.
+            ### Path Variable
+            - **clubId**: 입력할 동아리의 ID  \n
+            
+            ### Request Body
+            - **month**: 월 (integer, 1~12 사이) \n
+            - **content**: 활동 내용 (string, 30자 미만) \n
+            - **scheduleId**: 활동 ID (수정 시에만 필요)
+            """)
+    @PostMapping("/club-admin/{clubId}/schedules/draft")
+    public ApiResponse<?> postClubSchedulesDraft(
+            @PathVariable Long clubId,
+            @RequestBody ClubScheduleListRequestDTO clubActivityDTO) {
+        return ApiResponse.onSuccess(clubCommandService.saveAndUpdateClubScheduleDraft(clubId, clubActivityDTO));
+    }
+
+    
 
     /*----------------------------- 동아리 소개글 ------------------------------*/
     @Tag(name = "동아리 소개 - 소개글", description = "동아리 소개 관련 API")

--- a/src/main/java/kr/hanjari/backend/web/dto/club/request/ClubDetailRequestDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/request/ClubDetailRequestDTO.java
@@ -4,6 +4,7 @@ import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 
 public record ClubDetailRequestDTO(
         RecruitmentStatus recruitmentStatus,
+        String oneLiner,
         String leaderName,
         String leaderPhone,
         String activities,

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubResponseDTO.java
@@ -23,7 +23,7 @@ public record ClubResponseDTO(
         return new ClubResponseDTO(
                 club.getId(),
                 club.getName(),
-                club.getBriefIntroduction(),
+                club.getOneLiner(),
                 club.getCategory(),
                 club.getRecruitmentStatus(),
                 profileImageUrl,

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ClubDetailDraftResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ClubDetailDraftResponseDTO.java
@@ -1,26 +1,36 @@
 package kr.hanjari.backend.web.dto.club.response.draft;
 
+import kr.hanjari.backend.domain.Club;
 import kr.hanjari.backend.domain.draft.ClubDetailDraft;
+import kr.hanjari.backend.domain.enums.ClubCategory;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 
 public record ClubDetailDraftResponseDTO(
+        String name,
+        String description,
+        ClubCategory category,
         RecruitmentStatus recruitmentStatus,
         String leaderName,
         String leaderPhone,
         String activities,
         Integer membershipFee,
         String snsUrl,
-        String applicationUrl
+        String applicationUrl,
+        String profileImageUrl
 )  {
-    public static ClubDetailDraftResponseDTO of(ClubDetailDraft clubDetailDraft) {
+    public static ClubDetailDraftResponseDTO of(ClubDetailDraft clubDetailDraft, Club club, String profileImage) {
         return new ClubDetailDraftResponseDTO(
+                club.getName(),
+                club.getBriefIntroduction(),
+                club.getCategory(),
                 clubDetailDraft.getRecruitmentStatus(),
                 clubDetailDraft.getLeaderName(),
                 clubDetailDraft.getLeaderPhone(),
                 clubDetailDraft.getActivities(),
                 clubDetailDraft.getMembershipFee(),
                 clubDetailDraft.getSnsUrl(),
-                clubDetailDraft.getApplicationUrl()
+                clubDetailDraft.getApplicationUrl(),
+                profileImage
         );
     }
 }

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ClubDetailDraftResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ClubDetailDraftResponseDTO.java
@@ -21,7 +21,7 @@ public record ClubDetailDraftResponseDTO(
     public static ClubDetailDraftResponseDTO of(ClubDetailDraft clubDetailDraft, Club club, String profileImage) {
         return new ClubDetailDraftResponseDTO(
                 club.getName(),
-                club.getBriefIntroduction(),
+                club.getOneLiner(),
                 club.getCategory(),
                 clubDetailDraft.getRecruitmentStatus(),
                 clubDetailDraft.getLeaderName(),

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ClubDetailDraftResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ClubDetailDraftResponseDTO.java
@@ -1,4 +1,4 @@
-package kr.hanjari.backend.web.dto.club.response;
+package kr.hanjari.backend.web.dto.club.response.draft;
 
 import kr.hanjari.backend.domain.draft.ClubDetailDraft;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ClubIntroductionDraftResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ClubIntroductionDraftResponseDTO.java
@@ -1,13 +1,17 @@
 package kr.hanjari.backend.web.dto.club.response.draft;
 
+import kr.hanjari.backend.domain.Club;
 import kr.hanjari.backend.domain.draft.IntroductionDraft;
+import kr.hanjari.backend.web.dto.club.response.ClubResponseDTO;
 
 public record ClubIntroductionDraftResponseDTO(
+        ClubResponseDTO club,
         String introduction,
         String activity,
         String recruitment) {
-    public static ClubIntroductionDraftResponseDTO of(IntroductionDraft introductionDraft) {
+    public static ClubIntroductionDraftResponseDTO of(Club club, IntroductionDraft introductionDraft, String profileImageUrl) {
         return new ClubIntroductionDraftResponseDTO(
+                ClubResponseDTO.of(club, profileImageUrl),
                 introductionDraft.getContent1(),
                 introductionDraft.getContent2(),
                 introductionDraft.getContent3()

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ClubIntroductionDraftResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ClubIntroductionDraftResponseDTO.java
@@ -1,4 +1,4 @@
-package kr.hanjari.backend.web.dto.club.response;
+package kr.hanjari.backend.web.dto.club.response.draft;
 
 import kr.hanjari.backend.domain.draft.IntroductionDraft;
 

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ClubRecruitmentDraftResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ClubRecruitmentDraftResponseDTO.java
@@ -1,14 +1,18 @@
 package kr.hanjari.backend.web.dto.club.response.draft;
 
+import kr.hanjari.backend.domain.Club;
 import kr.hanjari.backend.domain.draft.RecruitmentDraft;
+import kr.hanjari.backend.web.dto.club.response.ClubResponseDTO;
 
 public record ClubRecruitmentDraftResponseDTO(
+        ClubResponseDTO club,
         String due,
         String notice,
         String etc )
 {
-    public static ClubRecruitmentDraftResponseDTO of(RecruitmentDraft recruitment) {
+    public static ClubRecruitmentDraftResponseDTO of(Club club, RecruitmentDraft recruitment, String profileImageUrl) {
         return new ClubRecruitmentDraftResponseDTO(
+                ClubResponseDTO.of(club, profileImageUrl),
                 recruitment.getContent1(),
                 recruitment.getContent2(),
                 recruitment.getContent3()

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ClubRecruitmentDraftResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ClubRecruitmentDraftResponseDTO.java
@@ -1,6 +1,5 @@
-package kr.hanjari.backend.web.dto.club.response;
+package kr.hanjari.backend.web.dto.club.response.draft;
 
-import kr.hanjari.backend.domain.Recruitment;
 import kr.hanjari.backend.domain.draft.RecruitmentDraft;
 
 public record ClubRecruitmentDraftResponseDTO(

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ClubScheduleDraftResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ClubScheduleDraftResponseDTO.java
@@ -1,0 +1,14 @@
+package kr.hanjari.backend.web.dto.club.response.draft;
+
+import java.util.List;
+import kr.hanjari.backend.domain.Schedule;
+import kr.hanjari.backend.domain.draft.ScheduleDraft;
+
+public record ClubScheduleDraftResponseDTO (List<ScheduleDraftResponseDTO> schedules, Integer totalElements){
+    public static ClubScheduleDraftResponseDTO of(List<ScheduleDraft> schecduleList) {
+        return new ClubScheduleDraftResponseDTO(
+            schecduleList.stream().map(ScheduleDraftResponseDTO::of).toList(),
+            schecduleList.size()
+        );
+    }
+}

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ScheduleDraftResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ScheduleDraftResponseDTO.java
@@ -1,0 +1,10 @@
+package kr.hanjari.backend.web.dto.club.response.draft;
+
+import kr.hanjari.backend.domain.Schedule;
+import kr.hanjari.backend.domain.draft.ScheduleDraft;
+
+public record ScheduleDraftResponseDTO (Long id, Integer month, String content){
+    public static ScheduleDraftResponseDTO of(ScheduleDraft schedule) {
+        return new ScheduleDraftResponseDTO(schedule.getId(), schedule.getMonth(), schedule.getContent());
+    }
+}


### PR DESCRIPTION
## 💻 작업사항

- 동아리 월 별 일정 임시저장 API 구현
- 임시 저장 값 조회 응답 값에 동아리 정보 포함하도록 코드 수정


## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
