### PR TITLE
✨ [FEATURE] 동아리 가입 승인 : 이메일 전송 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	implementation 'org.springframework.boot:spring-boot-starter-mail' // mail
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/hanjari/backend/payload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/hanjari/backend/payload/code/status/ErrorStatus.java
@@ -25,6 +25,8 @@ public enum ErrorStatus implements BaseErrorCode {
     _INVALID_TOKEN_SIGNATURE(HttpStatus.UNAUTHORIZED, "USER401", "유효하지 않은 토큰 서명입니다."),
     _INVALID_TOKEN_FORMAT(HttpStatus.BAD_REQUEST, "USER400", "잘못된 토큰 형식입니다"),
 
+    _FAIL_TO_SEND_EMAIL(HttpStatus.BAD_REQUEST, "CLUB400", "메일 전송이 실패하였습니다."),
+
     // 총동연 관련
     _UNION_ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "UNION_ANNOUNCEMENT404", "공지사항을 찾을 수 없습니다."),
 

--- a/src/main/java/kr/hanjari/backend/service/club/ClubUtil.java
+++ b/src/main/java/kr/hanjari/backend/service/club/ClubUtil.java
@@ -24,7 +24,7 @@ import software.amazon.awssdk.services.s3.endpoints.internal.Value.Str;
 @Transactional
 public class ClubUtil {
 
-    @Value("spring.mail.username")
+    @Value("${spring.mail.username}")
     private String serviceEmail;
 
 

--- a/src/main/java/kr/hanjari/backend/service/club/ClubUtil.java
+++ b/src/main/java/kr/hanjari/backend/service/club/ClubUtil.java
@@ -1,24 +1,39 @@
 package kr.hanjari.backend.service.club;
 
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 import kr.hanjari.backend.domain.Club;
 import kr.hanjari.backend.payload.code.status.ErrorStatus;
 import kr.hanjari.backend.payload.exception.GeneralException;
 import kr.hanjari.backend.repository.ClubRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
 import java.util.Random;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import software.amazon.awssdk.services.s3.endpoints.internal.Value.Str;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class ClubUtil {
 
+    @Value("spring.mail.username")
+    private String serviceEmail;
+
+
     private final ClubRepository clubRepository;
+    private final JavaMailSender javaMailSender;
+    private final TemplateEngine templateEngine;
 
     private static final String CHAR_POOL = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"; // 코드에 사용할 문자 집합
+    private static final String SUBJECT = "[한자리] 동아리 신청 승인 결과 안내드립니다. ";
     private static final int CODE_LENGTH = 6; // 코드 길이
 
     private final Random random = new SecureRandom();
@@ -39,6 +54,42 @@ public class ClubUtil {
         return code;
     }
 
+    public void sendEmail(
+            String email, String clubName, String verificationCode, String loginUrl) {
+        MimeMessage message = javaMailSender.createMimeMessage();
+
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            helper.setFrom(serviceEmail);
+            helper.setTo(email);
+            helper.setSubject(SUBJECT);
+
+
+            String htmlContent = createApproveContent(clubName, verificationCode, loginUrl);
+
+            helper.setText(htmlContent, true);
+
+            javaMailSender.send(message);
+
+        } catch (MessagingException e) {
+            throw new GeneralException(ErrorStatus._FAIL_TO_SEND_EMAIL);
+        }
+    }
+
+
+    private String createApproveContent(
+             String clubName, String verificationCode, String loginUrl) {
+
+        Context context = new Context();
+        context.setVariable("clubName", clubName);
+        context.setVariable("verificationCode", verificationCode);
+        context.setVariable("loginUrl", loginUrl);
+
+        return templateEngine.process("success", context);
+    }
+
+
+
     private String generateRandomCode() {
         StringBuilder codeBuilder = new StringBuilder(CODE_LENGTH);
         for (int i = 0; i < CODE_LENGTH; i++) {
@@ -48,5 +99,7 @@ public class ClubUtil {
 
         return codeBuilder.toString();
     }
+
+
 
 }

--- a/src/main/java/kr/hanjari/backend/service/club/impl/ClubCommandServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/club/impl/ClubCommandServiceImpl.java
@@ -23,6 +23,7 @@ import kr.hanjari.backend.web.dto.club.response.ScheduleListResponseDTO;
 import kr.hanjari.backend.web.dto.club.response.draft.ClubScheduleDraftResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -32,6 +33,9 @@ import org.springframework.web.multipart.MultipartFile;
 @Transactional
 @RequiredArgsConstructor
 public class ClubCommandServiceImpl implements ClubCommandService {
+
+    @Value("${login.url}")
+    private String loginURL;
 
     private final ClubRepository clubRepository;
     private final ClubRegistrationRepository clubRegistrationRepository;
@@ -72,7 +76,9 @@ public class ClubCommandServiceImpl implements ClubCommandService {
         clubRegistrationRepository.deleteById(clubRegistrationId);
 
         Long newClubId = clubRegistration.getId();
-        clubUtil.reissueClubCode(newClubId);
+        String code = clubUtil.reissueClubCode(newClubId);
+
+        clubUtil.sendEmail(newClub.getLeaderEmail(), newClub.getName(), code, loginURL);
         return newClub.getId();
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -43,6 +43,7 @@ spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.timeout=5000
 spring.mail.properties.mail.smtp.starttls.enable=true
 
+login.url=${LOGIN_URL}
 
 # JWT
 jwt.secret-key=${JWT_SECRET_KEY}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,6 +34,16 @@ spring.servlet.multipart.max-request-size=10MB
 spring.data.redis.host=${REDIS_HOST}
 spring.data.redis.port=${REDIS_PORT}
 
+# Mail
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=${MAIL_USERNAME}
+spring.mail.password=${MAIL_PASSWORD}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.timeout=5000
+spring.mail.properties.mail.smtp.starttls.enable=true
+
+
 # JWT
 jwt.secret-key=${JWT_SECRET_KEY}
 jwt.blacklist-key=${JWT_BLACKLIST_KEY}

--- a/src/main/resources/templates/success.html
+++ b/src/main/resources/templates/success.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>가입 승인 안내</title>
+</head>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+<div style="max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #ddd; border-radius: 10px;">
+  <h2 style="color: #007bff;">🎉 가입 신청이 승인되었습니다!</h2>
+  <p>안녕하세요,</p>
+  <p><strong><span th:text="${clubName}"></span></strong> 동아리 가입 신청이 승인되었습니다.</p>
+  <p>아래의 6자리 로그인 인증 코드를 사용하여 서비스를 이용하실 수 있습니다.</p>
+  <div style="font-size: 24px; font-weight: bold; color: #007bff; text-align: center; padding: 10px; border: 2px solid #007bff;">
+    <span th:text="${verificationCode}"></span>
+  </div>
+  <p style="text-align: center; margin-top: 20px;">
+    <a th:href="@{${loginUrl}}" style="display: inline-block; padding: 10px 20px; color: #fff; background-color: #007bff; text-decoration: none; border-radius: 5px;">
+      로그인 하기
+    </a>
+  </p>
+  <p>감사합니다.<br><strong>한자리 팀 드림.</strong></p>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/success.html
+++ b/src/main/resources/templates/success.html
@@ -7,15 +7,15 @@
 </head>
 <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
 <div style="max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #ddd; border-radius: 10px;">
-  <h2 style="color: #007bff;">🎉 가입 신청이 승인되었습니다!</h2>
-  <p>안녕하세요,</p>
+  <h2 style="color: #33639C;">🎉 가입 신청이 승인되었습니다!</h2>
+  <p>안녕하세요!</p>
   <p><strong><span th:text="${clubName}"></span></strong> 동아리 가입 신청이 승인되었습니다.</p>
   <p>아래의 6자리 로그인 인증 코드를 사용하여 서비스를 이용하실 수 있습니다.</p>
-  <div style="font-size: 24px; font-weight: bold; color: #007bff; text-align: center; padding: 10px; border: 2px solid #007bff;">
+  <div style="font-size: 24px; font-weight: bold; color: #33639C; text-align: center; padding: 10px; border: 2px solid #33639C;">
     <span th:text="${verificationCode}"></span>
   </div>
   <p style="text-align: center; margin-top: 20px;">
-    <a th:href="@{${loginUrl}}" style="display: inline-block; padding: 10px 20px; color: #fff; background-color: #007bff; text-decoration: none; border-radius: 5px;">
+    <a th:href="@{${loginUrl}}" style="display: inline-block; padding: 10px 20px; color: #fff; background-color: #33639C; text-decoration: none; border-radius: 5px;">
       로그인 하기
     </a>
   </p>


### PR DESCRIPTION
## 💻 작업사항

- 동아리 가입 승인 시,  인증 코드를 포함한 안내 이메일을 전송합니다. 
<img width="689" alt="스크린샷 2025-03-07 오후 7 47 54" src="https://github.com/user-attachments/assets/794fc49f-e428-4052-9725-d18404454bca" />

- 위 인증 코드는 예시 코드입니다.

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
