### PR TITLE
[FEATURE] 동아리 신청 화면 리뉴얼로 인한 동아리 엔티티 구조 및 API 변경

### DIFF
--- a/src/main/java/kr/hanjari/backend/domain/Club.java
+++ b/src/main/java/kr/hanjari/backend/domain/Club.java
@@ -1,5 +1,7 @@
 package kr.hanjari.backend.domain;
 
+import static java.util.Objects.requireNonNull;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -11,9 +13,16 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import kr.hanjari.backend.domain.command.CategoryCommand;
 import kr.hanjari.backend.domain.common.BaseEntity;
 import kr.hanjari.backend.domain.enums.CentralClubCategory;
+import kr.hanjari.backend.domain.enums.ClubType;
+import kr.hanjari.backend.domain.enums.College;
+import kr.hanjari.backend.domain.enums.Department;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
+import kr.hanjari.backend.domain.enums.UnionClubCategory;
+import kr.hanjari.backend.payload.code.status.ErrorStatus;
+import kr.hanjari.backend.payload.exception.GeneralException;
 import kr.hanjari.backend.web.dto.club.request.ClubBasicInformationDTO;
 import kr.hanjari.backend.web.dto.club.request.ClubDetailRequestDTO;
 import lombok.AllArgsConstructor;
@@ -77,6 +86,94 @@ public class Club extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "recruitment_status", nullable = false)
     private RecruitmentStatus recruitmentStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "club_type", nullable = false)
+    private ClubType clubType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "central_category")
+    private CentralClubCategory centralCategory;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "union_category")
+    private UnionClubCategory unionCategory;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "college")
+    private College college;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "department")
+    private Department department;
+
+    // 팩토리 메서드
+    public static Club create(
+            String code,
+            String name,
+            String leaderEmail,
+            RecruitmentStatus recruitmentStatus,
+            CategoryCommand categoryCommand,
+            String oneLiner,
+            String briefIntroduction
+    ) {
+        Club club = Club.builder()
+                .code(code)
+                .name(name)
+                .leaderEmail(leaderEmail)
+                .recruitmentStatus(recruitmentStatus)
+                .oneLiner(oneLiner)
+                .briefIntroduction(briefIntroduction)
+                .build();
+
+        // 카테고리 설정 및 타입별 검증
+        club.setCategory(categoryCommand);
+
+        return club;
+    }
+
+    // 팩토리/업데이트 시 불변성 체크를 위한 메서드
+    public void setCategory(CategoryCommand cmd) {
+        switch (cmd.type()) {
+            case CENTRAL -> {
+                requireNonNull(cmd.central());
+                this.centralCategory = cmd.central();
+                this.unionCategory = null;
+                this.college = null;
+                this.department = null;
+            }
+            case UNION -> {
+                requireNonNull(cmd.union());
+                this.unionCategory = cmd.union();
+                this.centralCategory = null;
+                this.college = null;
+                this.department = null;
+            }
+            case COLLEGE -> { // 단과대 학회(과 X)
+                requireNonNull(cmd.college());
+                this.college = cmd.college();
+                this.department = null;
+                this.centralCategory = null;
+                this.unionCategory = null;
+            }
+            case DEPARTMENT -> { // 과 학회(과 O)
+                requireNonNull(cmd.college());
+                requireNonNull(cmd.department());
+                validateDepartmentIsBelongToCollage(cmd);
+                this.college = cmd.college();
+                this.department = cmd.department();
+                this.centralCategory = null;
+                this.unionCategory = null;
+            }
+        }
+        this.clubType = cmd.type();
+    }
+
+    private static void validateDepartmentIsBelongToCollage(CategoryCommand cmd) {
+        if (cmd.department().getCollege() != cmd.college()) {
+            throw new GeneralException(ErrorStatus._DEPARTMENT_IS_NOT_BELONG_TO_COLLEGE);
+        }
+    }
 
     public void updateClubImage(File imageFile) {
         this.imageFile = imageFile;

--- a/src/main/java/kr/hanjari/backend/domain/Club.java
+++ b/src/main/java/kr/hanjari/backend/domain/Club.java
@@ -1,11 +1,21 @@
 package kr.hanjari.backend.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import kr.hanjari.backend.domain.common.BaseEntity;
-import kr.hanjari.backend.domain.enums.ClubCategory;
+import kr.hanjari.backend.domain.enums.CentralClubCategory;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
-import kr.hanjari.backend.web.dto.club.request.ClubDetailRequestDTO;
 import kr.hanjari.backend.web.dto.club.request.ClubBasicInformationDTO;
+import kr.hanjari.backend.web.dto.club.request.ClubDetailRequestDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,7 +45,7 @@ public class Club extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "category", nullable = false)
-    private ClubCategory category;
+    private CentralClubCategory category;
 
     @Column(name = "leader_name", length = 30)
     private String leaderName;
@@ -76,7 +86,7 @@ public class Club extends BaseEntity {
         this.recruitmentStatus = detail.recruitmentStatus();
         this.leaderName = detail.leaderName();
         this.leaderPhone = detail.leaderPhone();
-        this.membershipFee = detail. membershipFee();
+        this.membershipFee = detail.membershipFee();
         this.meetingSchedule = detail.activities();
         this.snsUrl = detail.snsUrl();
         this.applicationUrl = detail.applicationUrl();
@@ -85,7 +95,7 @@ public class Club extends BaseEntity {
     public void updateClubCommonInfo(ClubBasicInformationDTO commonInfo) {
         this.name = commonInfo.clubName();
         this.leaderEmail = commonInfo.leaderEmail();
-        this.category = ClubCategory.valueOf(commonInfo.category());
+        this.category = CentralClubCategory.valueOf(commonInfo.category());
         this.oneLiner = commonInfo.oneLiner();
         this.briefIntroduction = commonInfo.briefIntroduction();
     }

--- a/src/main/java/kr/hanjari/backend/domain/ClubRegistration.java
+++ b/src/main/java/kr/hanjari/backend/domain/ClubRegistration.java
@@ -1,8 +1,18 @@
 package kr.hanjari.backend.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import kr.hanjari.backend.domain.common.BaseEntity;
-import kr.hanjari.backend.domain.enums.ClubCategory;
+import kr.hanjari.backend.domain.enums.CentralClubCategory;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,7 +39,7 @@ public class ClubRegistration extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "category", nullable = false)
-    private ClubCategory category;
+    private CentralClubCategory category;
 
     @Column(name = "leader_email", nullable = false, length = 40)
     private String leaderEmail;

--- a/src/main/java/kr/hanjari/backend/domain/ClubRegistration.java
+++ b/src/main/java/kr/hanjari/backend/domain/ClubRegistration.java
@@ -1,9 +1,8 @@
 package kr.hanjari.backend.domain;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -11,8 +10,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import kr.hanjari.backend.domain.command.CategoryCommand;
 import kr.hanjari.backend.domain.common.BaseEntity;
-import kr.hanjari.backend.domain.enums.CentralClubCategory;
+import kr.hanjari.backend.domain.vo.ClubCategoryInfo;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -37,10 +37,6 @@ public class ClubRegistration extends BaseEntity {
     @Column(name = "name", nullable = false, length = 30)
     private String name;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "category", nullable = false)
-    private CentralClubCategory category;
-
     @Column(name = "leader_email", nullable = false, length = 40)
     private String leaderEmail;
 
@@ -50,18 +46,31 @@ public class ClubRegistration extends BaseEntity {
     @Column(name = "brief_introduction", nullable = false, length = 120)
     private String briefIntroduction;
 
+    @Embedded
+    private ClubCategoryInfo categoryInfo;
+
+    // 팩토리 메서드
+    public static ClubRegistration create(
+            String name,
+            String leaderEmail,
+            CategoryCommand categoryCommand,
+            String oneLiner,
+            String briefIntroduction
+    ) {
+
+        return ClubRegistration.builder()
+                .name(name)
+                .leaderEmail(leaderEmail)
+                .oneLiner(oneLiner)
+                .briefIntroduction(briefIntroduction)
+                .categoryInfo(ClubCategoryInfo.from(categoryCommand))
+                .build();
+    }
+
+    // 팩토리/업데이트 시 불변성 체크를 위한 메서드
+
     public void updateImageFile(File imageFile) {
         this.imageFile = imageFile;
     }
 
-    public Club toClub() {
-        return Club.builder()
-                .imageFile(imageFile)
-                .name(name)
-                .category(category)
-                .leaderEmail(leaderEmail)
-                .oneLiner(oneLiner)
-                .briefIntroduction(briefIntroduction)
-                .build();
-    }
 }

--- a/src/main/java/kr/hanjari/backend/domain/command/CategoryCommand.java
+++ b/src/main/java/kr/hanjari/backend/domain/command/CategoryCommand.java
@@ -1,0 +1,21 @@
+package kr.hanjari.backend.domain.command;
+
+import kr.hanjari.backend.domain.enums.CentralClubCategory;
+import kr.hanjari.backend.domain.enums.ClubType;
+import kr.hanjari.backend.domain.enums.College;
+import kr.hanjari.backend.domain.enums.Department;
+import kr.hanjari.backend.domain.enums.UnionClubCategory;
+
+public record CategoryCommand(
+        ClubType type,
+        CentralClubCategory central,
+        UnionClubCategory union,
+        College college,
+        Department department
+) {
+    public static CategoryCommand of(ClubType type, CentralClubCategory central, UnionClubCategory union,
+                                     College college, Department department) {
+        return new CategoryCommand(type, central, union, college, department);
+    }
+
+}

--- a/src/main/java/kr/hanjari/backend/domain/enums/CentralClubCategory.java
+++ b/src/main/java/kr/hanjari/backend/domain/enums/CentralClubCategory.java
@@ -1,10 +1,19 @@
 package kr.hanjari.backend.domain.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum CentralClubCategory {
-    VOLUNTEER,    // 봉사
-    ART,          // 예술
-    SPORTS,       // 체육
-    RELIGION,     // 종교
-    ACADEMIC,     // 학술교양
-    UNION         // 연합동아리
+    VOLUNTEER("봉사분과"),
+    ART("예술분과"),
+    SPORTS("체육분과"),
+    RELIGION("종교분과"),
+    ACADEMIC("학술교양분과");
+
+    private final String description;
+
+    CentralClubCategory(String description) {
+        this.description = description;
+    }
+
 }

--- a/src/main/java/kr/hanjari/backend/domain/enums/CentralClubCategory.java
+++ b/src/main/java/kr/hanjari/backend/domain/enums/CentralClubCategory.java
@@ -1,6 +1,6 @@
 package kr.hanjari.backend.domain.enums;
 
-public enum ClubCategory {
+public enum CentralClubCategory {
     VOLUNTEER,    // 봉사
     ART,          // 예술
     SPORTS,       // 체육

--- a/src/main/java/kr/hanjari/backend/domain/enums/ClubType.java
+++ b/src/main/java/kr/hanjari/backend/domain/enums/ClubType.java
@@ -3,6 +3,6 @@ package kr.hanjari.backend.domain.enums;
 public enum ClubType {
     CENTRAL,
     UNION,
+    COLLEGE,
     DEPARTMENT,
-    MAJOR
 }

--- a/src/main/java/kr/hanjari/backend/domain/enums/ClubType.java
+++ b/src/main/java/kr/hanjari/backend/domain/enums/ClubType.java
@@ -1,0 +1,8 @@
+package kr.hanjari.backend.domain.enums;
+
+public enum ClubType {
+    CENTRAL,
+    UNION,
+    DEPARTMENT,
+    MAJOR
+}

--- a/src/main/java/kr/hanjari/backend/domain/enums/ClubType.java
+++ b/src/main/java/kr/hanjari/backend/domain/enums/ClubType.java
@@ -1,8 +1,18 @@
 package kr.hanjari.backend.domain.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum ClubType {
-    CENTRAL,
-    UNION,
-    COLLEGE,
-    DEPARTMENT,
+    CENTRAL("중앙동아리"),
+    UNION("연합동아리"),
+    COLLEGE("단과대학회"),
+    DEPARTMENT("과학회");
+
+    private final String description;
+
+    ClubType(String description) {
+        this.description = description;
+    }
+
 }

--- a/src/main/java/kr/hanjari/backend/domain/enums/College.java
+++ b/src/main/java/kr/hanjari/backend/domain/enums/College.java
@@ -1,0 +1,25 @@
+package kr.hanjari.backend.domain.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum College {
+
+    GLOBAL_LAW_COMMUNICATION("글로벌문화통상대학"),
+    KYUNG_SANG("경상대학"),
+    COMMUNICATION_CULTURE("커뮤니케이션&컬쳐대학"),
+    ENGINEERING("공학대학"),
+    CONVERGENCE("첨단융합대학"),
+    SOFTWARE("소프트웨어융합대학"),
+    DESIGN("디자인대학"),
+    PHARMACY("약학대학"),
+    SPORT_ARTS("예체능대학"),
+    LIONS_COLLEGE("LIONS칼리지");
+
+    private final String description;
+
+    College(String description) {
+        this.description = description;
+    }
+
+}

--- a/src/main/java/kr/hanjari/backend/domain/enums/Department.java
+++ b/src/main/java/kr/hanjari/backend/domain/enums/Department.java
@@ -1,0 +1,83 @@
+package kr.hanjari.backend.domain.enums;
+
+import java.util.Arrays;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public enum Department {
+    // 공학대학
+    ARCHITECTURE("건축학부", College.ENGINEERING),
+    CONSTRUCTION_ENVIRONMENT("건설환경공학과", College.ENGINEERING),
+    TRANSPORT_LOGISTICS("교통·물류공학과", College.ENGINEERING),
+    ELECTRICAL_ENGINEERING("전자공학부", College.ENGINEERING),
+    BATTERY_MATERIAL_CHEMICAL("배터리소재화학공학과", College.ENGINEERING),
+    MATERIAL_CHEMICAL("재료화학공학과", College.ENGINEERING),
+    MECHANICAL("기계공학과", College.ENGINEERING),
+    INDUSTRIAL_MANAGEMENT("산업경영공학과", College.ENGINEERING),
+    ROBOT("로봇공학과", College.ENGINEERING),
+    FUSION_SYSTEM("융합시스템공학과", College.ENGINEERING),
+    SMART_FUSION("스마트융합공학부", College.ENGINEERING),
+    INTELLIGENT_ROBOT("지능형로봇학과", College.ENGINEERING),
+    ENERGY_BIO("에너지바이오학과", College.ENGINEERING),
+    MARINE_FUSION("해양융합공학과", College.ENGINEERING),
+
+    // 소프트웨어융합대학
+    COMPUTER("컴퓨터학부", College.SOFTWARE),
+    ICT("ICT융합학부", College.SOFTWARE),
+    AI("인공지능학부", College.SOFTWARE),
+    DATA("데이터사이언스학부", College.SOFTWARE),
+
+    // 약학대학
+    PHARMACY("약학과", College.PHARMACY),
+
+    // 첨단융합대학
+    SEMICONDUCTOR("차세대반도체융합공학부", College.CONVERGENCE),
+    BIO("바이오신약융합학부", College.CONVERGENCE),
+    DEFENSE_INTELLIGENCE("국방지능정보융합공학부", College.CONVERGENCE),
+
+    // 글로벌문화통상대학
+    KOREAN_STUDIES("한국언어문학과", College.GLOBAL_LAW_COMMUNICATION),
+    CHINA_STUDIES("중국학과", College.GLOBAL_LAW_COMMUNICATION),
+    JAPAN_STUDIES("일본학과", College.GLOBAL_LAW_COMMUNICATION),
+    ENGLISH_STUDIES("영미언어문화학과", College.GLOBAL_LAW_COMMUNICATION),
+    FRENCH_STUDIES("프랑스학과", College.GLOBAL_LAW_COMMUNICATION),
+
+    // 커뮤니케이션&컬쳐대학
+    ADVERTISING("광고홍보학과", College.COMMUNICATION_CULTURE),
+    MEDIA("미디어학과", College.COMMUNICATION_CULTURE),
+    CULTURE("문화콘텐츠학과", College.COMMUNICATION_CULTURE),
+    ANTHROPOLOGY("문화인류학과", College.COMMUNICATION_CULTURE),
+
+    // 경상대학
+    BUSINESS_ADMINISTRATION("경영학부", College.KYUNG_SANG),
+    ECONOMICS("경제학과", College.KYUNG_SANG),
+    ACTUARIAL_SCIENCE("보험계리학과", College.KYUNG_SANG),
+    ACCOUNTING("회계세무학과", College.KYUNG_SANG),
+
+    // 디자인대학
+    INTEGRATED_DESIGN("융합디자인학부", College.DESIGN),
+    JEWELRY("주얼리/패션디자인학과", College.DESIGN),
+    INDUSTRIAL_DESIGN("산업디자인학과", College.DESIGN),
+    COMMUNICATION_DESIGN("커뮤니케이션디자인학과", College.DESIGN),
+    MEDIA_DESIGN("영상디자인학과", College.DESIGN),
+
+    // 예체능
+    SPORTS_SCIENCE("스포츠과학부", College.SPORT_ARTS),
+    DANCE("무용학과", College.SPORT_ARTS),
+    MUSIC("실용음악학과", College.SPORT_ARTS);
+    
+    private final String description;
+    private final College college;
+
+    Department(String description, College college) {
+        this.description = description;
+        this.college = college;
+    }
+
+    public static List<Department> findByCollege(College college) {
+        return Arrays.stream(values())
+                .filter(dept -> dept.getCollege() == college)
+                .toList();
+    }
+}

--- a/src/main/java/kr/hanjari/backend/domain/enums/UnionClubCategory.java
+++ b/src/main/java/kr/hanjari/backend/domain/enums/UnionClubCategory.java
@@ -1,0 +1,23 @@
+package kr.hanjari.backend.domain.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum UnionClubCategory {
+    IT("IT"),
+    MARKETING_AD("마케팅/광고"),
+    ECONOMY_MANAGEMENT("경제/경영"),
+    VOLUNTEER("봉사"),
+    SPORTS("스포츠"),
+    LANGUAGE("언어"),
+    PRESENTATION("발표"),
+    BOOK("독서"),
+    ETC("그 외 기타");
+
+    private final String description;
+
+    UnionClubCategory(String description) {
+        this.description = description;
+    }
+
+}

--- a/src/main/java/kr/hanjari/backend/domain/vo/ClubCategoryInfo.java
+++ b/src/main/java/kr/hanjari/backend/domain/vo/ClubCategoryInfo.java
@@ -1,0 +1,113 @@
+package kr.hanjari.backend.domain.vo;
+
+import static java.util.Objects.requireNonNull;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import kr.hanjari.backend.domain.command.CategoryCommand;
+import kr.hanjari.backend.domain.enums.CentralClubCategory;
+import kr.hanjari.backend.domain.enums.ClubType;
+import kr.hanjari.backend.domain.enums.College;
+import kr.hanjari.backend.domain.enums.Department;
+import kr.hanjari.backend.domain.enums.UnionClubCategory;
+import kr.hanjari.backend.payload.code.status.ErrorStatus;
+import kr.hanjari.backend.payload.exception.GeneralException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 공통 VO
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ClubCategoryInfo {
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "club_type", nullable = false)
+    private ClubType clubType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "central_category")
+    private CentralClubCategory centralCategory;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "union_category")
+    private UnionClubCategory unionCategory;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "college")
+    private College college;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "department")
+    private Department department;
+    
+    private ClubCategoryInfo(ClubType type,
+                             CentralClubCategory central,
+                             UnionClubCategory union,
+                             College college,
+                             Department department) {
+        validate(type, central, union, college, department);
+        this.clubType = type;
+        this.centralCategory = central;
+        this.unionCategory = union;
+        this.college = college;
+        this.department = department;
+    }
+
+    public static ClubCategoryInfo from(CategoryCommand cmd) {
+        return new ClubCategoryInfo(cmd.type(), cmd.central(), cmd.union(), cmd.college(), cmd.department());
+    }
+
+    public void apply(CategoryCommand cmd) {
+        validate(cmd.type(), cmd.central(), cmd.union(), cmd.college(), cmd.department());
+        this.clubType = cmd.type();
+        this.centralCategory = cmd.central();
+        this.unionCategory = cmd.union();
+        this.college = cmd.college();
+        this.department = cmd.department();
+    }
+
+    private static void validate(ClubType type,
+                                 CentralClubCategory central,
+                                 UnionClubCategory union,
+                                 College college,
+                                 Department department) {
+        switch (type) {
+            case CENTRAL -> {
+                requireNonNull(central, "CENTRAL은 centralCategory 필수");
+                ensureNull(union, college, department);
+            }
+            case UNION -> {
+                requireNonNull(union, "UNION은 unionCategory 필수");
+                ensureNull(central, college, department);
+            }
+            case COLLEGE -> {
+                requireNonNull(college, "COLLEGE는 college 필수");
+                ensureNull(central, union, department);
+            }
+            case DEPARTMENT -> {
+                requireNonNull(college, "DEPARTMENT는 college 필수");
+                requireNonNull(department, "DEPARTMENT는 department 필수");
+                validateDepartmentIsBelongToCollage(college, department);
+                ensureNull(central, union);
+            }
+        }
+    }
+
+    private static void validateDepartmentIsBelongToCollage(College college, Department department) {
+        if (department.getCollege() != college) {
+            throw new GeneralException(ErrorStatus._DEPARTMENT_IS_NOT_BELONG_TO_COLLEGE);
+        }
+    }
+
+    private static void ensureNull(Object... objs) {
+        for (Object o : objs) {
+            if (o != null) {
+                throw new GeneralException(ErrorStatus._INVALID_INPUT);
+            }
+        }
+    }
+}

--- a/src/main/java/kr/hanjari/backend/payload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/hanjari/backend/payload/code/status/ErrorStatus.java
@@ -15,8 +15,9 @@ public enum ErrorStatus implements BaseErrorCode {
     _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+    _INVALID_INPUT(HttpStatus.BAD_REQUEST, "MAJOR400", "유효하지 않은 입력입니다."),
 
-    // 단과대 관련
+    // 단과대 관련,
     _DEPARTMENT_IS_NOT_BELONG_TO_COLLEGE(HttpStatus.BAD_REQUEST, "MAJOR400", "해당 단과대에 속하지 않는 전공입니다."),
 
     // 사용자 관련

--- a/src/main/java/kr/hanjari/backend/payload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/hanjari/backend/payload/code/status/ErrorStatus.java
@@ -16,6 +16,9 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
+    // 단과대 관련
+    _DEPARTMENT_IS_NOT_BELONG_TO_COLLEGE(HttpStatus.BAD_REQUEST, "MAJOR400", "해당 단과대에 속하지 않는 전공입니다."),
+
     // 사용자 관련
     _INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "USER401", "유효하지 않은 토큰입니다."),
     _TOKEN_ALREADY_LOGOUT(HttpStatus.BAD_REQUEST, "USER400", "이미 로그아웃 처리된 토큰입니다."),
@@ -52,7 +55,8 @@ public enum ErrorStatus implements BaseErrorCode {
     _RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "RECRUITMENT404", "동아리 모집 안내를 찾을 수 없습니다."),
     _RECRUITMENT_DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "RECRUITMENT404", "임시 저장 된 동아리 모집 안내를 찾을 수 없습니다."),
 
-    _SERVICE_ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "SERVICE_ANNOUNCEMENT404", "공지사항을 찾을 수 없습니다."),;
+    _SERVICE_ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "SERVICE_ANNOUNCEMENT404", "공지사항을 찾을 수 없습니다."),
+    ;
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/kr/hanjari/backend/repository/ClubRepository.java
+++ b/src/main/java/kr/hanjari/backend/repository/ClubRepository.java
@@ -2,7 +2,7 @@ package kr.hanjari.backend.repository;
 
 import java.util.Optional;
 import kr.hanjari.backend.domain.Club;
-import kr.hanjari.backend.domain.enums.ClubCategory;
+import kr.hanjari.backend.domain.enums.CentralClubCategory;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,12 +16,13 @@ import org.springframework.stereotype.Repository;
 public interface ClubRepository extends JpaRepository<Club, Long>, JpaSpecificationExecutor<Club> {
 
     Optional<Club> findByName(String clubName);
+
     Optional<Club> findByCode(String code);
+
     boolean existsByCode(String code);
 
     @Query("SELECT c.name FROM Club c WHERE c.id = :clubId")
     Optional<String> findClubNameById(@Param("clubId") Long clubId);
-
 
 
     @Query("SELECT c FROM Club c WHERE (:name IS NULL OR c.name LIKE %:name%) " +
@@ -32,6 +33,7 @@ public interface ClubRepository extends JpaRepository<Club, Long>, JpaSpecificat
             "     WHEN c.recruitmentStatus = 'UPCOMING' THEN 1 " +
             "     WHEN c.recruitmentStatus = 'CLOSED' THEN 2 " +
             "     ELSE 3 END ASC, c.name ASC")
-    Page<Club> findClubsOrderByRecruitmentStatus(String name, ClubCategory category, RecruitmentStatus status, Pageable pageable);
+    Page<Club> findClubsOrderByRecruitmentStatus(String name, CentralClubCategory category, RecruitmentStatus status,
+                                                 Pageable pageable);
 
 }

--- a/src/main/java/kr/hanjari/backend/repository/ClubRepository.java
+++ b/src/main/java/kr/hanjari/backend/repository/ClubRepository.java
@@ -9,24 +9,17 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ClubRepository extends JpaRepository<Club, Long>, JpaSpecificationExecutor<Club> {
 
-    Optional<Club> findByName(String clubName);
-
     Optional<Club> findByCode(String code);
 
     boolean existsByCode(String code);
 
-    @Query("SELECT c.name FROM Club c WHERE c.id = :clubId")
-    Optional<String> findClubNameById(@Param("clubId") Long clubId);
-
-
     @Query("SELECT c FROM Club c WHERE (:name IS NULL OR c.name LIKE %:name%) " +
-            "AND (:category IS NULL OR c.category = :category) " +
+            "AND (:category IS NULL OR c.categoryInfo.centralCategory = :category) " +
             "AND (:status IS NULL OR c.recruitmentStatus = :status) " +
             "ORDER BY " +
             "CASE WHEN c.recruitmentStatus = 'OPEN' THEN 0 " +

--- a/src/main/java/kr/hanjari/backend/repository/specification/ClubSpecifications.java
+++ b/src/main/java/kr/hanjari/backend/repository/specification/ClubSpecifications.java
@@ -4,22 +4,22 @@ import jakarta.persistence.criteria.Predicate;
 import java.util.ArrayList;
 import java.util.List;
 import kr.hanjari.backend.domain.Club;
-import kr.hanjari.backend.domain.enums.ClubCategory;
+import kr.hanjari.backend.domain.enums.CentralClubCategory;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 import org.springframework.data.jpa.domain.Specification;
 
 public class ClubSpecifications {
 
     public static Specification<Club> findByCondition(
-            String name, ClubCategory clubCategory, RecruitmentStatus recruitmentStatus) {
+            String name, CentralClubCategory centralClubCategory, RecruitmentStatus recruitmentStatus) {
 
         return (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
             if (name != null) {
                 predicates.add(cb.like(root.get("name"), "%" + name + "%"));
             }
-            if (clubCategory != null) {
-                predicates.add(cb.equal(root.get("category"), clubCategory));
+            if (centralClubCategory != null) {
+                predicates.add(cb.equal(root.get("category"), centralClubCategory));
             }
             if (recruitmentStatus != null) {
                 predicates.add(cb.equal(root.get("recruitmentStatus"), recruitmentStatus));

--- a/src/main/java/kr/hanjari/backend/service/club/ClubQueryService.java
+++ b/src/main/java/kr/hanjari/backend/service/club/ClubQueryService.java
@@ -1,7 +1,7 @@
 package kr.hanjari.backend.service.club;
 
 
-import kr.hanjari.backend.domain.enums.ClubCategory;
+import kr.hanjari.backend.domain.enums.CentralClubCategory;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 import kr.hanjari.backend.domain.enums.SortBy;
 import kr.hanjari.backend.web.dto.club.response.ClubIntroductionResponseDTO;
@@ -24,7 +24,7 @@ public interface ClubQueryService {
 
     // 조건 별 동아리 검색
     ClubSearchResponseDTO findClubsByCondition(
-            String name, ClubCategory category, RecruitmentStatus status, SortBy sortBy, int page,
+            String name, CentralClubCategory category, RecruitmentStatus status, SortBy sortBy, int page,
             int size);
 
     // 동아리 상세 조회

--- a/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/service/club/impl/ClubQueryServiceImpl.java
@@ -11,7 +11,7 @@ import kr.hanjari.backend.domain.draft.ClubDetailDraft;
 import kr.hanjari.backend.domain.draft.IntroductionDraft;
 import kr.hanjari.backend.domain.draft.RecruitmentDraft;
 import kr.hanjari.backend.domain.draft.ScheduleDraft;
-import kr.hanjari.backend.domain.enums.ClubCategory;
+import kr.hanjari.backend.domain.enums.CentralClubCategory;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 import kr.hanjari.backend.domain.enums.SortBy;
 import kr.hanjari.backend.payload.code.status.ErrorStatus;
@@ -82,7 +82,7 @@ public class ClubQueryServiceImpl implements ClubQueryService {
 
     @Override
     public ClubSearchResponseDTO findClubsByCondition(
-            String name, ClubCategory category, RecruitmentStatus status, SortBy sortBy, int page,
+            String name, CentralClubCategory category, RecruitmentStatus status, SortBy sortBy, int page,
             int size) {
         List<String> profileImageUrls = new ArrayList<>();
         if (sortBy != null && sortBy.equals(SortBy.RECRUITMENT_STATUS_ASC)) {

--- a/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
+++ b/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
@@ -71,6 +71,7 @@ public class ClubController {
     @PostMapping("/registrations")
     public ApiResponse<Long> requestClubRegistration(@RequestPart ClubBasicInformationDTO requestBody,
                                                      @RequestPart MultipartFile image) {
+        requestBody.validate();
 
         Long result = clubCommandService.requestClubRegistration(requestBody, image);
         return ApiResponse.onSuccess(result);

--- a/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
+++ b/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
@@ -63,6 +63,8 @@ public class ClubController {
             - **category**: 동아리 카테고리(SPORTS, ART, VOLUNTEER, UNION, ACADEMIC, RELIGION)
             - **oneLiner**: 동아리 한줄소개
             - **briefIntroduction**: 동아리 간단소개
+            - **clubType**: 동아리 유형(CENTRAL, UNION, COLLEGE, DEPARTMENT)
+            + 카테고리와 관련된 디테일한 내용은 슬랙을 참고해주세요.
             #### image (multipart/form-data)
             - **동아리 대표 이미지**
             ### Response
@@ -115,6 +117,8 @@ public class ClubController {
             - **category**: 동아리 카테고리(SPORTS, ART)
             - **oneLiner**: 동아리 한줄소개
             - **briefIntroduction**: 동아리 간단소개
+            - **clubType**: 동아리 유형(CENTRAL, UNION, COLLEGE, DEPARTMENT)
+            + 카테고리와 관련된 디테일한 내용은 슬랙을 참고해주세요.
             ### Multipart/form-data
             - **image**: 동아리 대표 사진
             """)

--- a/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
+++ b/src/main/java/kr/hanjari/backend/web/controller/ClubController.java
@@ -3,7 +3,7 @@ package kr.hanjari.backend.web.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Objects;
-import kr.hanjari.backend.domain.enums.ClubCategory;
+import kr.hanjari.backend.domain.enums.CentralClubCategory;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 import kr.hanjari.backend.domain.enums.SortBy;
 import kr.hanjari.backend.payload.ApiResponse;
@@ -144,7 +144,7 @@ public class ClubController {
     @GetMapping("")
     public ApiResponse<ClubSearchResponseDTO> getClubsByCondition(
             @RequestParam(required = false) String keyword,
-            @RequestParam(required = false) ClubCategory category,
+            @RequestParam(required = false) CentralClubCategory category,
             @RequestParam(required = false) RecruitmentStatus status,
             @RequestParam(required = false) SortBy sortBy,
             @RequestParam(defaultValue = "0") int page,

--- a/src/main/java/kr/hanjari/backend/web/dto/club/request/ClubBasicInformationDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/request/ClubBasicInformationDTO.java
@@ -11,7 +11,7 @@ public record ClubBasicInformationDTO(
         String clubName,    // 동아리 이름
         String leaderEmail, // 동아리장 이메일
         ClubType clubType,  // 동아리 유형 (CENTRAL, UNION, COLLEGE, DEPARTMENT)
-        CategoryDTO categoryDTO,  // 카테고리 정보 (유형별로 필요한 필드만 채움)
+        CategoryDTO category,  // 카테고리 정보 (유형별로 필요한 필드만 채움)
         String oneLiner,    // 한 줄 소개
         String briefIntroduction // 간단한 설명
 ) {
@@ -28,32 +28,34 @@ public record ClubBasicInformationDTO(
         if (clubType == null) {
             throw new IllegalArgumentException("clubType은 필수 값입니다.");
         }
-        if (categoryDTO == null) {
+        if (category == null) {
             throw new IllegalArgumentException("category는 필수 값입니다.");
         }
 
         switch (clubType) {
             case CENTRAL -> { // 중앙 동아리
-                requireNonNull(categoryDTO.central(), "CENTRAL 유형에서는 centralCategory가 필수입니다.");
-                requireNull(categoryDTO.union(), "CENTRAL 유형에서는 unionCategory를 지정할 수 없습니다.");
-                requireNull(categoryDTO.college(), "CENTRAL 유형에서는 college를 지정할 수 없습니다.");
-                requireNull(categoryDTO.department(), "CENTRAL 유형에서는 department를 지정할 수 없습니다.");
+                requireNonNull(category.central(), "CENTRAL 유형에서는 centralCategory가 필수입니다.");
+                requireNull(category.union(), "CENTRAL 유형에서는 unionCategory를 지정할 수 없습니다.");
+                requireNull(category.college(), "CENTRAL 유형에서는 college를 지정할 수 없습니다.");
+                requireNull(category.department(), "CENTRAL 유형에서는 department를 지정할 수 없습니다.");
             }
             case UNION -> { // 연합 동아리
-                requireNonNull(categoryDTO.union(), "UNION 유형에서는 unionCategory가 필수입니다.");
-                requireNull(categoryDTO.central(), "UNION 유형에서는 centralCategory를 지정할 수 없습니다.");
-                requireNull(categoryDTO.college(), "UNION 유형에서는 college를 지정할 수 없습니다.");
-                requireNull(categoryDTO.department(), "UNION 유형에서는 department를 지정할 수 없습니다.");
+                requireNonNull(category.union(), "UNION 유형에서는 unionCategory가 필수입니다.");
+                requireNull(category.central(), "UNION 유형에서는 centralCategory를 지정할 수 없습니다.");
+                requireNull(category.college(), "UNION 유형에서는 college를 지정할 수 없습니다.");
+                requireNull(category.department(), "UNION 유형에서는 department를 지정할 수 없습니다.");
             }
             case COLLEGE -> { // 단과대 학회 (과 정보 없음)
-                requireNonNull(categoryDTO.college(), "COLLEGE 유형에서는 college가 필수입니다.");
-                requireNull(categoryDTO.central(), "COLLEGE 유형에서는 centralCategory를 지정할 수 없습니다.");
-                requireNull(categoryDTO.union(), "COLLEGE 유형에서는 unionCategory를 지정할 수 없습니다.");
-                requireNull(categoryDTO.department(), "COLLEGE 유형에서는 department를 지정할 수 없습니다.");
+                requireNonNull(category.college(), "COLLEGE 유형에서는 college가 필수입니다.");
+                requireNull(category.central(), "COLLEGE 유형에서는 centralCategory를 지정할 수 없습니다.");
+                requireNull(category.union(), "COLLEGE 유형에서는 unionCategory를 지정할 수 없습니다.");
+                requireNull(category.department(), "COLLEGE 유형에서는 department를 지정할 수 없습니다.");
             }
             case DEPARTMENT -> { // 과 학회 (과 정보 있음)
-                requireNonNull(categoryDTO.college(), "DEPARTMENT 유형에서는 college가 필수입니다.");
-                requireNonNull(categoryDTO.department(), "DEPARTMENT 유형에서는 department가 필수입니다.");
+                requireNull(category.union(), "DEPARTMENT 유형에서는 unionCategory를 지정할 수 없습니다.");
+                requireNull(category.central(), "DEPARTMENT 유형에서는 centralCategory를 지정할 수 없습니다.");
+                requireNonNull(category.college(), "DEPARTMENT 유형에서는 college가 필수입니다.");
+                requireNonNull(category.department(), "DEPARTMENT 유형에서는 department가 필수입니다.");
             }
         }
     }
@@ -73,10 +75,10 @@ public record ClubBasicInformationDTO(
     public CategoryCommand toCategoryCommand() {
         return new CategoryCommand(
                 clubType,
-                categoryDTO.central(),
-                categoryDTO.union(),
-                categoryDTO.college(),
-                categoryDTO.department()
+                category.central(),
+                category.union(),
+                category.college(),
+                category.department()
         );
     }
 

--- a/src/main/java/kr/hanjari/backend/web/dto/club/request/ClubBasicInformationDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/request/ClubBasicInformationDTO.java
@@ -1,7 +1,7 @@
 package kr.hanjari.backend.web.dto.club.request;
 
 import kr.hanjari.backend.domain.ClubRegistration;
-import kr.hanjari.backend.domain.enums.ClubCategory;
+import kr.hanjari.backend.domain.enums.CentralClubCategory;
 
 
 public record ClubBasicInformationDTO(String clubName,
@@ -11,14 +11,15 @@ public record ClubBasicInformationDTO(String clubName,
                                       String briefIntroduction
 ) {
 
-    public static ClubBasicInformationDTO of(String clubName, String leaderEmail, String category, String oneLiner, String briefIntroduction) {
+    public static ClubBasicInformationDTO of(String clubName, String leaderEmail, String category, String oneLiner,
+                                             String briefIntroduction) {
         return new ClubBasicInformationDTO(clubName, leaderEmail, category, oneLiner, briefIntroduction);
     }
 
     public ClubRegistration toClubRegistration() {
         return ClubRegistration.builder()
                 .name(clubName())
-                .category(ClubCategory.valueOf(category()))
+                .category(CentralClubCategory.valueOf(category()))
                 .leaderEmail(leaderEmail())
                 .oneLiner(oneLiner())
                 .briefIntroduction(briefIntroduction())

--- a/src/main/java/kr/hanjari/backend/web/dto/club/request/ClubBasicInformationDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/request/ClubBasicInformationDTO.java
@@ -1,28 +1,84 @@
 package kr.hanjari.backend.web.dto.club.request;
 
-import kr.hanjari.backend.domain.ClubRegistration;
+import kr.hanjari.backend.domain.command.CategoryCommand;
 import kr.hanjari.backend.domain.enums.CentralClubCategory;
+import kr.hanjari.backend.domain.enums.ClubType;
+import kr.hanjari.backend.domain.enums.College;
+import kr.hanjari.backend.domain.enums.Department;
+import kr.hanjari.backend.domain.enums.UnionClubCategory;
 
-
-public record ClubBasicInformationDTO(String clubName,
-                                      String leaderEmail,
-                                      String category,
-                                      String oneLiner,
-                                      String briefIntroduction
+public record ClubBasicInformationDTO(
+        String clubName,    // 동아리 이름
+        String leaderEmail, // 동아리장 이메일
+        ClubType clubType,  // 동아리 유형 (CENTRAL, UNION, COLLEGE, DEPARTMENT)
+        CategoryDTO categoryDTO,  // 카테고리 정보 (유형별로 필요한 필드만 채움)
+        String oneLiner,    // 한 줄 소개
+        String briefIntroduction // 간단한 설명
 ) {
 
-    public static ClubBasicInformationDTO of(String clubName, String leaderEmail, String category, String oneLiner,
-                                             String briefIntroduction) {
-        return new ClubBasicInformationDTO(clubName, leaderEmail, category, oneLiner, briefIntroduction);
+    public record CategoryDTO(
+            CentralClubCategory central, // 중앙동아리 카테고리
+            UnionClubCategory union,     // 연합동아리 카테고리
+            College college,             // 단과대
+            Department department        // 학과
+    ) {
     }
 
-    public ClubRegistration toClubRegistration() {
-        return ClubRegistration.builder()
-                .name(clubName())
-                .category(CentralClubCategory.valueOf(category()))
-                .leaderEmail(leaderEmail())
-                .oneLiner(oneLiner())
-                .briefIntroduction(briefIntroduction())
-                .build();
+    public void validate() {
+        if (clubType == null) {
+            throw new IllegalArgumentException("clubType은 필수 값입니다.");
+        }
+        if (categoryDTO == null) {
+            throw new IllegalArgumentException("category는 필수 값입니다.");
+        }
+
+        switch (clubType) {
+            case CENTRAL -> { // 중앙 동아리
+                requireNonNull(categoryDTO.central(), "CENTRAL 유형에서는 centralCategory가 필수입니다.");
+                requireNull(categoryDTO.union(), "CENTRAL 유형에서는 unionCategory를 지정할 수 없습니다.");
+                requireNull(categoryDTO.college(), "CENTRAL 유형에서는 college를 지정할 수 없습니다.");
+                requireNull(categoryDTO.department(), "CENTRAL 유형에서는 department를 지정할 수 없습니다.");
+            }
+            case UNION -> { // 연합 동아리
+                requireNonNull(categoryDTO.union(), "UNION 유형에서는 unionCategory가 필수입니다.");
+                requireNull(categoryDTO.central(), "UNION 유형에서는 centralCategory를 지정할 수 없습니다.");
+                requireNull(categoryDTO.college(), "UNION 유형에서는 college를 지정할 수 없습니다.");
+                requireNull(categoryDTO.department(), "UNION 유형에서는 department를 지정할 수 없습니다.");
+            }
+            case COLLEGE -> { // 단과대 학회 (과 정보 없음)
+                requireNonNull(categoryDTO.college(), "COLLEGE 유형에서는 college가 필수입니다.");
+                requireNull(categoryDTO.central(), "COLLEGE 유형에서는 centralCategory를 지정할 수 없습니다.");
+                requireNull(categoryDTO.union(), "COLLEGE 유형에서는 unionCategory를 지정할 수 없습니다.");
+                requireNull(categoryDTO.department(), "COLLEGE 유형에서는 department를 지정할 수 없습니다.");
+            }
+            case DEPARTMENT -> { // 과 학회 (과 정보 있음)
+                requireNonNull(categoryDTO.college(), "DEPARTMENT 유형에서는 college가 필수입니다.");
+                requireNonNull(categoryDTO.department(), "DEPARTMENT 유형에서는 department가 필수입니다.");
+            }
+        }
     }
+
+    private static void requireNonNull(Object o, String m) {
+        if (o == null) {
+            throw new IllegalArgumentException(m);
+        }
+    }
+
+    private static void requireNull(Object o, String m) {
+        if (o != null) {
+            throw new IllegalArgumentException(m);
+        }
+    }
+
+    public CategoryCommand toCategoryCommand() {
+        return new CategoryCommand(
+                clubType,
+                categoryDTO.central(),
+                categoryDTO.union(),
+                categoryDTO.college(),
+                categoryDTO.department()
+        );
+    }
+
 }
+

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/CategoryResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/CategoryResponseDTO.java
@@ -3,6 +3,7 @@ package kr.hanjari.backend.web.dto.club.response;
 import kr.hanjari.backend.domain.vo.ClubCategoryInfo;
 
 public record CategoryResponseDTO(
+        String clubCategoryName,
         String centralCategoryName,
         String unionCategoryName,
         String collegeName,
@@ -10,10 +11,11 @@ public record CategoryResponseDTO(
 ) {
     public static CategoryResponseDTO from(ClubCategoryInfo categoryInfo) {
         return new CategoryResponseDTO(
-                categoryInfo.getCentralCategory().getDescription(),
-                categoryInfo.getUnionCategory().getDescription(),
-                categoryInfo.getCollege().getDescription(),
-                categoryInfo.getDepartment().getDescription()
+                categoryInfo.getClubType().getDescription(),
+                categoryInfo.getCentralCategory() == null ? null : categoryInfo.getCentralCategory().getDescription(),
+                categoryInfo.getUnionCategory() == null ? null : categoryInfo.getUnionCategory().getDescription(),
+                categoryInfo.getCollege() == null ? null : categoryInfo.getCollege().getDescription(),
+                categoryInfo.getDepartment() == null ? null : categoryInfo.getDepartment().getDescription()
         );
     }
 }

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/CategoryResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/CategoryResponseDTO.java
@@ -1,0 +1,19 @@
+package kr.hanjari.backend.web.dto.club.response;
+
+import kr.hanjari.backend.domain.vo.ClubCategoryInfo;
+
+public record CategoryResponseDTO(
+        String centralCategoryName,
+        String unionCategoryName,
+        String collegeName,
+        String departmentName
+) {
+    public static CategoryResponseDTO from(ClubCategoryInfo categoryInfo) {
+        return new CategoryResponseDTO(
+                categoryInfo.getCentralCategory().getDescription(),
+                categoryInfo.getUnionCategory().getDescription(),
+                categoryInfo.getCollege().getDescription(),
+                categoryInfo.getDepartment().getDescription()
+        );
+    }
+}

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubOverviewResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubOverviewResponseDTO.java
@@ -1,27 +1,26 @@
 package kr.hanjari.backend.web.dto.club.response;
 
 import kr.hanjari.backend.domain.Club;
-import kr.hanjari.backend.domain.enums.CentralClubCategory;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 
 public record ClubOverviewResponseDTO(
         Long id,
         String name,
         String description,
-        CentralClubCategory category,
         RecruitmentStatus recruitmentStatus,
         String profileImageUrl,
-        String applicationUrl
+        String applicationUrl,
+        CategoryResponseDTO category
 ) {
     public static ClubOverviewResponseDTO of(Club club, String profileImageUrl) {
         return new ClubOverviewResponseDTO(
                 club.getId(),
                 club.getName(),
                 club.getOneLiner(),
-                club.getCategory(),
                 club.getRecruitmentStatus(),
                 profileImageUrl,
-                club.getApplicationUrl()
+                club.getApplicationUrl(),
+                CategoryResponseDTO.from(club.getCategoryInfo())
         );
     }
 }

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubOverviewResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubOverviewResponseDTO.java
@@ -1,14 +1,14 @@
 package kr.hanjari.backend.web.dto.club.response;
 
 import kr.hanjari.backend.domain.Club;
-import kr.hanjari.backend.domain.enums.ClubCategory;
+import kr.hanjari.backend.domain.enums.CentralClubCategory;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 
 public record ClubOverviewResponseDTO(
         Long id,
         String name,
         String description,
-        ClubCategory category,
+        CentralClubCategory category,
         RecruitmentStatus recruitmentStatus,
         String profileImageUrl,
         String applicationUrl

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubRegistrationDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubRegistrationDTO.java
@@ -6,19 +6,19 @@ import kr.hanjari.backend.domain.ClubRegistration;
 public record ClubRegistrationDTO(
         Long clubRegistrationId,
         String clubName,
-        String category,
         String leaderEmail,
         String oneLiner,
-        String briefIntroduction
+        String briefIntroduction,
+        CategoryResponseDTO category
 ) {
     public static ClubRegistrationDTO from(ClubRegistration clubRegistration) {
         return new ClubRegistrationDTO(
                 clubRegistration.getId(),
                 clubRegistration.getName(),
-                clubRegistration.getCategory().name(),
                 clubRegistration.getLeaderEmail(),
                 clubRegistration.getOneLiner(),
-                clubRegistration.getBriefIntroduction()
+                clubRegistration.getBriefIntroduction(),
+                CategoryResponseDTO.from(clubRegistration.getCategoryInfo())
         );
     }
 }

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubResponseDTO.java
@@ -1,14 +1,12 @@
 package kr.hanjari.backend.web.dto.club.response;
 
 import kr.hanjari.backend.domain.Club;
-import kr.hanjari.backend.domain.enums.CentralClubCategory;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 
 public record ClubResponseDTO(
         Long id,
         String name,
         String description,
-        CentralClubCategory category,
         RecruitmentStatus recruitmentStatus,
         String profileImageUrl,
         String activities,
@@ -17,14 +15,14 @@ public record ClubResponseDTO(
         String leaderPhone,
         Integer membershipFee,
         String snsUrl,
-        String applicationUrl
+        String applicationUrl,
+        CategoryResponseDTO category
 ) {
     public static ClubResponseDTO of(Club club, String profileImageUrl) {
         return new ClubResponseDTO(
                 club.getId(),
                 club.getName(),
                 club.getOneLiner(),
-                club.getCategory(),
                 club.getRecruitmentStatus(),
                 profileImageUrl,
                 club.getMeetingSchedule(),
@@ -33,7 +31,8 @@ public record ClubResponseDTO(
                 club.getLeaderPhone(),
                 club.getMembershipFee(),
                 club.getSnsUrl(),
-                club.getApplicationUrl()
+                club.getApplicationUrl(),
+                CategoryResponseDTO.from(club.getCategoryInfo())
         );
     }
 }

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/ClubResponseDTO.java
@@ -1,14 +1,14 @@
 package kr.hanjari.backend.web.dto.club.response;
 
 import kr.hanjari.backend.domain.Club;
-import kr.hanjari.backend.domain.enums.ClubCategory;
+import kr.hanjari.backend.domain.enums.CentralClubCategory;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 
 public record ClubResponseDTO(
         Long id,
         String name,
         String description,
-        ClubCategory category,
+        CentralClubCategory category,
         RecruitmentStatus recruitmentStatus,
         String profileImageUrl,
         String activities,

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ClubDetailDraftResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ClubDetailDraftResponseDTO.java
@@ -2,13 +2,12 @@ package kr.hanjari.backend.web.dto.club.response.draft;
 
 import kr.hanjari.backend.domain.Club;
 import kr.hanjari.backend.domain.draft.ClubDetailDraft;
-import kr.hanjari.backend.domain.enums.CentralClubCategory;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
+import kr.hanjari.backend.web.dto.club.response.CategoryResponseDTO;
 
 public record ClubDetailDraftResponseDTO(
         String name,
         String description,
-        CentralClubCategory category,
         RecruitmentStatus recruitmentStatus,
         String leaderName,
         String leaderPhone,
@@ -16,13 +15,13 @@ public record ClubDetailDraftResponseDTO(
         Integer membershipFee,
         String snsUrl,
         String applicationUrl,
-        String profileImageUrl
+        String profileImageUrl,
+        CategoryResponseDTO category
 ) {
     public static ClubDetailDraftResponseDTO of(ClubDetailDraft clubDetailDraft, Club club, String profileImage) {
         return new ClubDetailDraftResponseDTO(
                 club.getName(),
                 club.getOneLiner(),
-                club.getCategory(),
                 clubDetailDraft.getRecruitmentStatus(),
                 clubDetailDraft.getLeaderName(),
                 clubDetailDraft.getLeaderPhone(),
@@ -30,7 +29,9 @@ public record ClubDetailDraftResponseDTO(
                 clubDetailDraft.getMembershipFee(),
                 clubDetailDraft.getSnsUrl(),
                 clubDetailDraft.getApplicationUrl(),
-                profileImage
+                profileImage,
+                CategoryResponseDTO.from(club.getCategoryInfo())
         );
     }
+
 }

--- a/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ClubDetailDraftResponseDTO.java
+++ b/src/main/java/kr/hanjari/backend/web/dto/club/response/draft/ClubDetailDraftResponseDTO.java
@@ -2,13 +2,13 @@ package kr.hanjari.backend.web.dto.club.response.draft;
 
 import kr.hanjari.backend.domain.Club;
 import kr.hanjari.backend.domain.draft.ClubDetailDraft;
-import kr.hanjari.backend.domain.enums.ClubCategory;
+import kr.hanjari.backend.domain.enums.CentralClubCategory;
 import kr.hanjari.backend.domain.enums.RecruitmentStatus;
 
 public record ClubDetailDraftResponseDTO(
         String name,
         String description,
-        ClubCategory category,
+        CentralClubCategory category,
         RecruitmentStatus recruitmentStatus,
         String leaderName,
         String leaderPhone,
@@ -17,7 +17,7 @@ public record ClubDetailDraftResponseDTO(
         String snsUrl,
         String applicationUrl,
         String profileImageUrl
-)  {
+) {
     public static ClubDetailDraftResponseDTO of(ClubDetailDraft clubDetailDraft, Club club, String profileImage) {
         return new ClubDetailDraftResponseDTO(
                 club.getName(),

--- a/src/test/java/kr/hanjari/backend/domain/vo/ClubCategoryDTOTest.java
+++ b/src/test/java/kr/hanjari/backend/domain/vo/ClubCategoryDTOTest.java
@@ -1,0 +1,199 @@
+package kr.hanjari.backend.domain.vo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import kr.hanjari.backend.domain.Club;
+import kr.hanjari.backend.domain.command.CategoryCommand;
+import kr.hanjari.backend.domain.enums.CentralClubCategory;
+import kr.hanjari.backend.domain.enums.ClubType;
+import kr.hanjari.backend.domain.enums.College;
+import kr.hanjari.backend.domain.enums.Department;
+import kr.hanjari.backend.domain.enums.RecruitmentStatus;
+import kr.hanjari.backend.domain.enums.UnionClubCategory;
+import kr.hanjari.backend.payload.exception.GeneralException;
+import kr.hanjari.backend.web.dto.club.request.ClubBasicInformationDTO;
+import kr.hanjari.backend.web.dto.club.request.ClubBasicInformationDTO.CategoryDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ClubCategoryDTOTest {
+
+    private Club newClub() {
+        return Club.builder()
+                .name("old")
+                .leaderEmail("old@univ.ac.kr")
+                .recruitmentStatus(RecruitmentStatus.UPCOMING)
+                .oneLiner("old one")
+                .briefIntroduction("old brief")
+                .categoryInfo(new ClubCategoryInfo())
+                .build();
+    }
+
+    @Test
+    @DisplayName("CENTRAL: centralCategory 설정 및 나머지 필드 초기화")
+    void centralCategory_set_and_clear_others() {
+        Club club = newClub();
+
+        ClubBasicInformationDTO dto = new ClubBasicInformationDTO(
+                "보안동아리",
+                "lead@univ.ac.kr",
+                ClubType.CENTRAL,
+                new CategoryDTO(CentralClubCategory.ACADEMIC,
+                        null,
+                        null,
+                        null),
+                "보안 좋아함",
+                "CTF 스터디");
+
+        dto.validate();
+        CategoryCommand cmd = dto.toCategoryCommand();
+
+        club.updateClubCommonInfo(dto, cmd);
+
+        assertEquals("보안동아리", club.getName());
+        assertEquals("lead@univ.ac.kr", club.getLeaderEmail());
+        assertEquals(ClubType.CENTRAL, club.getCategoryInfo().getClubType());
+        assertEquals(CentralClubCategory.ACADEMIC, club.getCategoryInfo().getCentralCategory());
+        assertNull(club.getCategoryInfo().getUnionCategory());
+        assertNull(club.getCategoryInfo().getCollege());
+        assertNull(club.getCategoryInfo().getDepartment());
+    }
+
+    @Test
+    @DisplayName("UNION: unionCategory 설정 및 나머지 필드 초기화")
+    void unionCategory_set_and_clear_others() {
+        Club club = newClub();
+
+        ClubBasicInformationDTO dto = new ClubBasicInformationDTO(
+                "연합마케팅",
+                "lead@univ.ac.kr",
+                ClubType.UNION,
+                new CategoryDTO(null, UnionClubCategory.MARKETING_AD, null, null),
+                "실전 마케팅",
+                "프로모션 실습"
+        );
+
+        dto.validate();
+        CategoryCommand cmd = dto.toCategoryCommand();
+
+        club.updateClubCommonInfo(dto, cmd);
+
+        assertEquals(ClubType.UNION, club.getCategoryInfo().getClubType());
+        assertEquals(UnionClubCategory.MARKETING_AD, club.getCategoryInfo().getUnionCategory());
+        assertNull(club.getCategoryInfo().getCentralCategory());
+        assertNull(club.getCategoryInfo().getCollege());
+        assertNull(club.getCategoryInfo().getDepartment());
+    }
+
+    @Test
+    @DisplayName("COLLEGE: college 설정(학과 없음) 및 나머지 필드 초기화")
+    void college_only_set_and_clear_others() {
+        Club club = newClub();
+
+        ClubBasicInformationDTO dto = new ClubBasicInformationDTO(
+                "공대 세미나",
+                "lead@univ.ac.kr",
+                ClubType.COLLEGE,
+                new CategoryDTO(null, null, College.ENGINEERING, null),
+                "공대 전체 세미나",
+                "격주 세미나"
+        );
+
+        dto.validate();
+        CategoryCommand cmd = dto.toCategoryCommand();
+
+        club.updateClubCommonInfo(dto, cmd);
+
+        assertEquals(ClubType.COLLEGE, club.getCategoryInfo().getClubType());
+        assertEquals(College.ENGINEERING, club.getCategoryInfo().getCollege());
+        assertNull(club.getCategoryInfo().getDepartment());
+        assertNull(club.getCategoryInfo().getUnionCategory());
+        assertNull(club.getCategoryInfo().getCentralCategory());
+    }
+
+    @Test
+    @DisplayName("DEPARTMENT: college + department 설정 및 관계 검증 통과")
+    void department_set_with_valid_relation() {
+        Club club = newClub();
+
+        ClubBasicInformationDTO dto = new ClubBasicInformationDTO(
+                "기계과 CAD 연구회",
+                "lead@univ.ac.kr",
+                ClubType.DEPARTMENT,
+                new CategoryDTO(null, null, College.ENGINEERING, Department.MECHANICAL),
+                "CAD 마스터",
+                "설계 툴 스터디"
+        );
+
+        dto.validate();
+        CategoryCommand cmd = dto.toCategoryCommand();
+
+        club.updateClubCommonInfo(dto, cmd);
+
+        assertEquals(ClubType.DEPARTMENT, club.getCategoryInfo().getClubType());
+        assertEquals(College.ENGINEERING, club.getCategoryInfo().getCollege());
+        assertEquals(Department.MECHANICAL, club.getCategoryInfo().getDepartment());
+        assertNull(club.getCategoryInfo().getCentralCategory());
+        assertNull(club.getCategoryInfo().getUnionCategory());
+    }
+
+    @Test
+    @DisplayName("DEPARTMENT: 학과-단과대 불일치 시 예외")
+    void department_set_with_invalid_relation_should_throw() {
+        Club club = newClub();
+
+        // 가정: Department.MECHANICAL 은 College.ENGINEERING 소속
+        ClubBasicInformationDTO dto = new ClubBasicInformationDTO(
+                "잘못된 소속 테스트",
+                "lead@univ.ac.kr",
+                ClubType.DEPARTMENT,
+                new CategoryDTO(null, null, College.SOFTWARE, Department.MECHANICAL),
+                "invalid",
+                "invalid"
+        );
+
+        dto.validate();
+        CategoryCommand cmd = dto.toCategoryCommand();
+
+        assertThrows(GeneralException.class, () -> club.updateClubCommonInfo(dto, cmd));
+    }
+
+    @Test
+    @DisplayName("DTO validate: 타입별 필수/금지 필드 검증 동작")
+    void dto_validate_should_work() {
+        // UNION 타입인데 central을 채우면 실패해야 함
+        ClubBasicInformationDTO bad = new ClubBasicInformationDTO(
+                "연합동아리",
+                "lead@univ.ac.kr",
+                ClubType.UNION,
+                new CategoryDTO(CentralClubCategory.ACADEMIC, null, null, null),
+                "bad",
+                "bad"
+        );
+
+        assertThrows(IllegalArgumentException.class, bad::validate);
+    }
+
+    @Test
+    @DisplayName("DTO → CategoryCommand 변환 확인")
+    void dto_to_command() {
+        ClubBasicInformationDTO dto = new ClubBasicInformationDTO(
+                "기계과 CAD 연구회",
+                "lead@univ.ac.kr",
+                ClubType.DEPARTMENT,
+                new CategoryDTO(null, null, College.ENGINEERING, Department.MECHANICAL),
+                "CAD",
+                "설계"
+        );
+        dto.validate();
+
+        CategoryCommand cmd = dto.toCategoryCommand();
+        assertEquals(ClubType.DEPARTMENT, cmd.type());
+        assertNull(cmd.central());
+        assertNull(cmd.union());
+        assertEquals(College.ENGINEERING, cmd.college());
+        assertEquals(Department.MECHANICAL, cmd.department());
+    }
+}


### PR DESCRIPTION
## 💻 작업사항

- `ClubCategory` VO 정의 
- `ClubBasicInformationDTO`에 `CategoryDTO` 중첩 레코드 추가
- `validate()` 메서드로 `clubType`별 카테고리 유효성 검증 로직 구현
    - 테스트 코드로 검증 
- `toCategoryCommand()` 메서드로 `DTO → Command` 변환 로직 추가

## 💡 작성한 이슈 외에 작업한 사항

- 프론트 전달용 Enum 요청 규칙 및 예시 문서 작성
- 동아리 검색 기능은 현재 일시적으로 수정해놓은 상태 
    - 추후 정상적으로 작동 하도록 수정 예정 

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
