### PR TITLE
[FEAT] 인스타그램 계정 조회 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // selenium
+    implementation 'org.seleniumhq.selenium:selenium-java:4.38.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/hanjari/backend/BackendApplication.java
+++ b/src/main/java/kr/hanjari/backend/BackendApplication.java
@@ -3,9 +3,11 @@ package kr.hanjari.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/kr/hanjari/backend/domain/club/application/query/ClubQueryService.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/application/query/ClubQueryService.java
@@ -8,14 +8,7 @@ import kr.hanjari.backend.domain.club.domain.enums.Department;
 import kr.hanjari.backend.domain.club.domain.enums.RecruitmentStatus;
 import kr.hanjari.backend.domain.club.domain.enums.SortBy;
 import kr.hanjari.backend.domain.club.domain.enums.UnionClubCategory;
-import kr.hanjari.backend.domain.club.presentation.dto.response.ClubDetailListResponse;
-import kr.hanjari.backend.domain.club.presentation.dto.response.ClubIntroductionResponse;
-import kr.hanjari.backend.domain.club.presentation.dto.response.ClubOverviewResponse;
-import kr.hanjari.backend.domain.club.presentation.dto.response.ClubRecruitmentResponse;
-import kr.hanjari.backend.domain.club.presentation.dto.response.ClubResponse;
-import kr.hanjari.backend.domain.club.presentation.dto.response.ClubScheduleResponse;
-import kr.hanjari.backend.domain.club.presentation.dto.response.ClubSearchResponse;
-import kr.hanjari.backend.domain.club.presentation.dto.response.GetRegistrationsResponse;
+import kr.hanjari.backend.domain.club.presentation.dto.response.*;
 import kr.hanjari.backend.domain.club.presentation.dto.response.draft.ClubBasicInfoResponse;
 import kr.hanjari.backend.domain.club.presentation.dto.response.draft.ClubDetailDraftResponse;
 import kr.hanjari.backend.domain.club.presentation.dto.response.draft.ClubIntroductionDraftResponse;
@@ -77,4 +70,6 @@ public interface ClubQueryService {
     ClubSearchResponse findThreeRecentUpdatedClubs();
 
     Club getReference(Long clubId);
+
+    GetOfficialAccounts fetchOfficialAccountsWithProfileImage();
 }

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/entity/detail/ClubInstagramImage.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/entity/detail/ClubInstagramImage.java
@@ -1,0 +1,32 @@
+package kr.hanjari.backend.domain.club.domain.entity.detail;
+
+import jakarta.persistence.*;
+import kr.hanjari.backend.domain.club.domain.entity.Club;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "club_instagram_iamge")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClubInstagramImage {
+
+    @Id
+    @Column(name = "club_id")
+    private Long clubId;
+
+    @MapsId(value = "clubId")
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id")
+    private Club club;
+
+    @Column(name = "url", length = 1024)
+    private String url;
+
+    public void update(String url) {
+        this.url = url;
+    }
+
+}

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/repository/ClubInstagramImageRepository.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/repository/ClubInstagramImageRepository.java
@@ -1,0 +1,7 @@
+package kr.hanjari.backend.domain.club.domain.repository;
+
+import kr.hanjari.backend.domain.club.domain.entity.detail.ClubInstagramImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClubInstagramImageRepository extends JpaRepository<ClubInstagramImage, Long> {
+}

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/repository/ClubRepository.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/repository/ClubRepository.java
@@ -1,5 +1,6 @@
 package kr.hanjari.backend.domain.club.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 import kr.hanjari.backend.domain.club.domain.entity.Club;
 import kr.hanjari.backend.domain.club.domain.enums.CentralClubCategory;
@@ -29,4 +30,6 @@ public interface ClubRepository extends JpaRepository<Club, Long>, JpaSpecificat
     Page<Club> findClubsOrderByRecruitmentStatus(String name, CentralClubCategory category, RecruitmentStatus status,
                                                  Pageable pageable);
 
+    @Query(value = "SELECT * FROM club ORDER BY RAND() LIMIT :limit", nativeQuery = true)
+    List<Club> findRandomClubsByLimit(int limit);
 }

--- a/src/main/java/kr/hanjari/backend/domain/club/presentation/controller/ClubController.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/presentation/controller/ClubController.java
@@ -11,15 +11,7 @@ import kr.hanjari.backend.domain.club.presentation.dto.request.ClubDetailRequest
 import kr.hanjari.backend.domain.club.presentation.dto.request.ClubIntroductionRequest;
 import kr.hanjari.backend.domain.club.presentation.dto.request.ClubRecruitmentRequest;
 import kr.hanjari.backend.domain.club.presentation.dto.request.ClubScheduleListRequest;
-import kr.hanjari.backend.domain.club.presentation.dto.response.ClubCodeResponse;
-import kr.hanjari.backend.domain.club.presentation.dto.response.ClubCommandResponse;
-import kr.hanjari.backend.domain.club.presentation.dto.response.ClubIntroductionResponse;
-import kr.hanjari.backend.domain.club.presentation.dto.response.ClubOverviewResponse;
-import kr.hanjari.backend.domain.club.presentation.dto.response.ClubRecruitmentResponse;
-import kr.hanjari.backend.domain.club.presentation.dto.response.ClubResponse;
-import kr.hanjari.backend.domain.club.presentation.dto.response.ClubScheduleResponse;
-import kr.hanjari.backend.domain.club.presentation.dto.response.GetRegistrationsResponse;
-import kr.hanjari.backend.domain.club.presentation.dto.response.ScheduleListResponse;
+import kr.hanjari.backend.domain.club.presentation.dto.response.*;
 import kr.hanjari.backend.domain.club.presentation.dto.response.draft.ClubBasicInfoResponse;
 import kr.hanjari.backend.domain.club.presentation.dto.response.draft.ClubDetailDraftResponse;
 import kr.hanjari.backend.domain.club.presentation.dto.response.draft.ClubIntroductionDraftResponse;
@@ -459,5 +451,12 @@ public class ClubController {
     @PostMapping("/service-admin/reissue")
     public ApiResponse<ClubCodeResponse> reissueClubCode(@RequestParam Long clubId) {
         return ApiResponse.onSuccess(ClubCodeResponse.of(codeGenerator.reissueCode(clubId)));
+    }
+
+    @GetMapping("/official-accounts")
+    public ApiResponse<GetOfficialAccounts> getOfficialAccounts() {
+        GetOfficialAccounts result = clubQueryService.fetchOfficialAccountsWithProfileImage();
+
+        return ApiResponse.onSuccess(result);
     }
 }

--- a/src/main/java/kr/hanjari/backend/domain/club/presentation/dto/ClubInstaAccountDTO.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/presentation/dto/ClubInstaAccountDTO.java
@@ -1,0 +1,12 @@
+package kr.hanjari.backend.domain.club.presentation.dto;
+
+public record ClubInstaAccountDTO(
+        String clubName,
+        String accountName,
+        String profileImage,
+        String instagramProfileUrl
+) {
+    public static ClubInstaAccountDTO of(String clubName, String accountName, String profileImage, String instagramProfileUrl) {
+        return new ClubInstaAccountDTO(clubName, accountName, profileImage, instagramProfileUrl);
+    }
+}

--- a/src/main/java/kr/hanjari/backend/domain/club/presentation/dto/response/GetOfficialAccounts.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/presentation/dto/response/GetOfficialAccounts.java
@@ -1,0 +1,13 @@
+package kr.hanjari.backend.domain.club.presentation.dto.response;
+
+import kr.hanjari.backend.domain.club.presentation.dto.ClubInstaAccountDTO;
+
+import java.util.List;
+
+public record GetOfficialAccounts(
+        List<ClubInstaAccountDTO> officialAccounts
+) {
+    public static GetOfficialAccounts of(List<ClubInstaAccountDTO> officialAccounts) {
+        return new GetOfficialAccounts(officialAccounts);
+    }
+}

--- a/src/main/java/kr/hanjari/backend/infrastructure/crawl/InstagramCrawler.java
+++ b/src/main/java/kr/hanjari/backend/infrastructure/crawl/InstagramCrawler.java
@@ -1,0 +1,97 @@
+package kr.hanjari.backend.infrastructure.crawl;
+
+import kr.hanjari.backend.domain.club.domain.entity.Club;
+import kr.hanjari.backend.domain.club.domain.entity.detail.ClubInstagramImage;
+import kr.hanjari.backend.domain.club.domain.repository.ClubInstagramImageRepository;
+import kr.hanjari.backend.domain.club.domain.repository.ClubRepository;
+import lombok.RequiredArgsConstructor;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class InstagramCrawler {
+
+    private final ClubRepository clubRepository;
+    private final ClubInstagramImageRepository clubInstagramImageRepository;
+
+    private static final String INSTAGRAM_URL = "https://www.instagram.com/";
+
+    @Scheduled(cron = "0 0 4 * * *")
+    public void update() {
+
+        WebDriver driver = null;
+
+        try {
+            driver = new ChromeDriver();
+
+            List<Club> clubList = clubRepository.findAll();
+            for (Club club : clubList) {
+                String account = club.getSnsUrl();
+                String profileImageUrl = getProfileImageUrl(account, driver);
+
+                ClubInstagramImage clubInstagramImage = clubInstagramImageRepository.findById(club.getId())
+                        .orElse(new ClubInstagramImage(club.getId(), club, profileImageUrl));
+
+                clubInstagramImage.update(profileImageUrl);
+                clubInstagramImageRepository.save(clubInstagramImage);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            if (driver != null) {
+                driver.quit();
+            }
+        }
+    }
+
+
+
+    private String getProfileImageUrl(String account, WebDriver driver) {
+        String profileUrl = INSTAGRAM_URL + account;
+
+        driver.get(profileUrl);
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+
+        String query = "//img[contains(@alt, '" + account + "')]";
+        // 대기
+        WebElement profileImageElement = wait.until(
+                ExpectedConditions.presenceOfElementLocated(By.xpath(query))
+        );
+
+        String imageUrl = profileImageElement.getAttribute("src");
+
+        if (imageUrl != null) {
+            return imageUrl;
+        }
+        return null;
+
+    }
+
+    private WebDriver getDriver() {
+        ChromeOptions options = new ChromeOptions();
+        // 백그라운드 실행
+        options.addArguments("--headless");
+        // sandbox 비활성화
+        options.addArguments("--no-sandbox");
+        // gpu 가속 비활성화
+        options.addArguments("--disable-gpu");
+        // 공유 메모리 비활성화
+        options.addArguments("--disable-dev-shm-usage");
+        options.addArguments("--window-size=1920,1080");
+
+        WebDriver driver = new ChromeDriver(options);
+
+        return driver;
+    }
+}


### PR DESCRIPTION
## 💻 작업사항

- 공식 계정 조회 api 추가
- 인스타그램 프로필 이미지 크롤러 추가
- 크롤링은 selenium 사용
- 실시간 크롤링 대신 스케줄링으로 db 캐싱하는 느낌으로 작성했습니다
- 자주 변경되는 부분은 아니라 캐시 만료 시간, 유효성 검사 등은 고려 안해도 괜찮을 것 같습니다

## 💡 작성한 이슈 외에 작업한 사항


## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
