### PR TITLE
[FEATURE] 모집 마감 상태도 모집 알림 수신 설정 가능하도록 조건 추가

### DIFF
--- a/src/main/java/kr/hanjari/backend/domain/club/application/command/impl/ClubCommandServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/application/command/impl/ClubCommandServiceImpl.java
@@ -193,9 +193,17 @@ public class ClubCommandServiceImpl implements ClubCommandService {
         RecruitmentStatus after = club.getRecruitmentStatus();
         clubRepository.save(club);
 
-        if (before == RecruitmentStatus.UPCOMING && after == RecruitmentStatus.OPEN) {
+        if (isBeforeOpenableStatus(before) && hasBecomeOpen(after)) {
             applicationEventPublisher.publishEvent(new RecruitmentStatusOpenedEvent(clubId, club.getName()));
         }
+    }
+
+    private boolean isBeforeOpenableStatus(RecruitmentStatus before) {
+        return before == RecruitmentStatus.UPCOMING || before == RecruitmentStatus.CLOSED;
+    }
+
+    private boolean hasBecomeOpen(RecruitmentStatus after) {
+        return after == RecruitmentStatus.OPEN;
     }
 
     @Override

--- a/src/test/java/kr/hanjari/backend/domain/club/application/command/impl/ClubCommandServiceImplRecruitmentAlertTest.java
+++ b/src/test/java/kr/hanjari/backend/domain/club/application/command/impl/ClubCommandServiceImplRecruitmentAlertTest.java
@@ -145,6 +145,24 @@ class ClubCommandServiceImplRecruitmentAlertTest {
     }
 
     @Test
+    @DisplayName("모집상태가 CLOSED에서 OPEN으로 바뀌면 이벤트를 발행한다")
+    void should_publish_event_when_recruitment_changes_closed_to_open() {
+        Long clubId = 171L;
+        Club club = club(clubId, "한자리", RecruitmentStatus.CLOSED);
+        when(clubRepository.findById(clubId)).thenReturn(Optional.of(club));
+
+        clubCommandService.updateClubRecruitmentStatus(clubId, 1);
+
+        ArgumentCaptor<RecruitmentStatusOpenedEvent> captor =
+            ArgumentCaptor.forClass(RecruitmentStatusOpenedEvent.class);
+        verify(applicationEventPublisher).publishEvent(captor.capture());
+        RecruitmentStatusOpenedEvent event = captor.getValue();
+        assertEquals(clubId, event.clubId());
+        assertEquals("한자리", event.clubName());
+        verify(clubRepository).save(club);
+    }
+
+    @Test
     @DisplayName("모집상태가 다른 전이면 이벤트를 발행하지 않는다")
     void should_not_publish_event_when_status_transition_is_not_upcoming_to_open() {
         Long clubId = 171L;


### PR DESCRIPTION
## 💻 작업사항

- 모집 마감 상태도 모집 알림 수신 설정 가능하도록 조건 추가

## 💡 작성한 이슈 외에 작업한 사항

- None

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
