### PR TITLE
[TEST] 조회수 동시성 전략별 테스트 API 추가

### DIFF
--- a/.claude/commands/push-pr.md
+++ b/.claude/commands/push-pr.md
@@ -14,7 +14,7 @@ Git push and create a Pull Request for the current branch.
 6. 사용자 확인 후 GitHub MCP(`mcp__github__create_pull_request`)로 PR 생성
 
 ## PR Title Rules
-- 형식: `[TYPE]: 한글 설명` (e.g. `[FEAT]: 로그인 기능 구현`)
+- 형식: `[TYPE] 한글 설명` (e.g. `[FEAT] 로그인 기능 구현`)
 - type 종류: `FEAT, FIX, REFACTOR, CHORE, DOCS, TEST`
 - type은 대문자, 마침표 없음, 명령형
 - 70자 이하

--- a/.gitignore
+++ b/.gitignore
@@ -180,4 +180,7 @@ gradle-app.setting
 
 AGENTS.md
 
+# k6 load test scripts
+src/test/k6/
+
 # End of https://www.toptal.com/developers/gitignore/api/java,gradle,macos,intellij+all

--- a/src/main/java/kr/hanjari/backend/domain/club/application/command/impl/ClubCommandServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/application/command/impl/ClubCommandServiceImpl.java
@@ -359,9 +359,10 @@ public class ClubCommandServiceImpl implements ClubCommandService {
 
     @Override
     public void incrementClubViewCount(Long clubId) {
-        Club club = getClub(clubId);
+//        Club club = getClub(clubId);
+        Club club = getClubWithXLock(clubId);
         club.incrementViewCount();
-        clubRepository.save(club);
+//        clubRepository.save(club);
     }
 
     // ======= Private Methods ======= //
@@ -382,6 +383,11 @@ public class ClubCommandServiceImpl implements ClubCommandService {
 
     private Club getClub(Long clubId) {
         return clubRepository.findById(clubId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
+    }
+
+    private Club getClubWithXLock(Long clubId) {
+        return clubRepository.findByIdWithPessimisticLock(clubId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
     }
 

--- a/src/main/java/kr/hanjari/backend/domain/club/application/query/impl/ClubQueryServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/application/query/impl/ClubQueryServiceImpl.java
@@ -128,8 +128,8 @@ public class ClubQueryServiceImpl implements ClubQueryService {
     @Override
     @Transactional
     public ClubDetailResponse findClubDetail(Long clubId) {
-        Club club = getClub(clubId);
         clubCommandService.incrementClubViewCount(clubId);
+        Club club = getClub(clubId);
 
         return ClubDetailResponse.of(
             club.getId(),

--- a/src/main/java/kr/hanjari/backend/domain/club/application/query/impl/ClubViewCountTestService.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/application/query/impl/ClubViewCountTestService.java
@@ -1,0 +1,78 @@
+package kr.hanjari.backend.domain.club.application.query.impl;
+
+import kr.hanjari.backend.domain.club.application.command.ClubCommandService;
+import kr.hanjari.backend.domain.club.domain.entity.Club;
+import kr.hanjari.backend.domain.club.domain.repository.ClubRepository;
+import kr.hanjari.backend.domain.club.presentation.dto.response.ClubDetailResponse;
+import kr.hanjari.backend.global.payload.code.status.ErrorStatus;
+import kr.hanjari.backend.global.payload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.security.core.parameters.P;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ClubViewCountTestService {
+
+    private final ClubRepository clubRepository;
+
+    private final StringRedisTemplate redisTemplate;
+
+
+    public ClubDetailResponse findClubDetailWithDirtyCheck(Long clubId) {
+        Club club = getClub(clubId);
+        club.incrementViewCount();
+        return getDTO(club);
+    }
+
+    public ClubDetailResponse findClubDetailWithPessimisticLock(Long clubId) {
+        Club club = getClubWithXLock(clubId);
+        club.incrementViewCount();
+        return getDTO(club);
+    }
+
+    public ClubDetailResponse findClubDetailWithOptimisticLock(Long clubId) {
+        Club club = getClub(clubId);
+
+        int updated = clubRepository.incrementViewCountWithVersionCheck(clubId, club.getVersion());
+
+        if (updated == 0) {
+            throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
+        }
+        return getDTO(club);
+    }
+
+    public ClubDetailResponse findClubDetailWithAtomicOperation(Long clubId) {
+        Club club = getClub(clubId);
+
+        clubRepository.incrementViewCount(clubId);
+        return getDTO(club);
+    }
+
+    public ClubDetailResponse findClubDetailWithRedis(Long clubId) {
+        Club club = getClub(clubId);
+
+        String key = "club:viewCount:" + clubId;
+        redisTemplate.opsForValue().increment(key);
+
+        return getDTO(club);
+    }
+
+    private ClubDetailResponse getDTO(Club club) {
+        return ClubDetailResponse.from(club);
+    }
+
+    private Club getClub(Long clubId) {
+        return clubRepository.findById(clubId)
+                .orElse(null);
+    }
+
+    private Club getClubWithXLock(Long clubId) {
+        return clubRepository.findByIdWithPessimisticLock(clubId)
+                .orElse(null);
+    }
+
+}

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/entity/Club.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/entity/Club.java
@@ -26,6 +26,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @Entity
@@ -42,6 +43,9 @@ public class Club extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ColumnDefault("0")
+    private Long version;
 
     @Column(name = "code")
     private String code;

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/repository/ClubRepository.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/repository/ClubRepository.java
@@ -9,10 +9,7 @@ import kr.hanjari.backend.domain.club.domain.enums.CentralClubCategory;
 import kr.hanjari.backend.domain.club.domain.enums.RecruitmentStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -23,6 +20,14 @@ public interface ClubRepository extends JpaRepository<Club, Long>, JpaSpecificat
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT c FROM Club c WHERE c.id = :id")
     Optional<Club> findByIdWithPessimisticLock(Long id);
+
+    @Modifying
+    @Query("UPDATE Club c SET c.viewCount = c.viewCount + 1, c.version = c.version + 1 WHERE c.id = :id AND c.version = :version")
+    int incrementViewCountWithVersionCheck(Long id, Long version);
+
+    @Modifying
+    @Query("UPDATE Club c SET c.viewCount = c.viewCount + 1 WHERE c.id = :id")
+    int incrementViewCount(Long id);
 
     boolean existsByCode(String code);
 

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/repository/ClubRepository.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/repository/ClubRepository.java
@@ -2,6 +2,8 @@ package kr.hanjari.backend.domain.club.domain.repository;
 
 import java.util.List;
 import java.util.Optional;
+
+import jakarta.persistence.LockModeType;
 import kr.hanjari.backend.domain.club.domain.entity.Club;
 import kr.hanjari.backend.domain.club.domain.enums.CentralClubCategory;
 import kr.hanjari.backend.domain.club.domain.enums.RecruitmentStatus;
@@ -9,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -16,6 +19,10 @@ import org.springframework.stereotype.Repository;
 public interface ClubRepository extends JpaRepository<Club, Long>, JpaSpecificationExecutor<Club> {
 
     Optional<Club> findByCode(String code);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM Club c WHERE c.id = :id")
+    Optional<Club> findByIdWithPessimisticLock(Long id);
 
     boolean existsByCode(String code);
 

--- a/src/main/java/kr/hanjari/backend/domain/club/presentation/controller/ClubViewCountTestController.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/presentation/controller/ClubViewCountTestController.java
@@ -1,0 +1,51 @@
+package kr.hanjari.backend.domain.club.presentation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.hanjari.backend.domain.club.application.query.impl.ClubViewCountTestService;
+import kr.hanjari.backend.domain.club.presentation.dto.response.ClubDetailResponse;
+import kr.hanjari.backend.global.payload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/test/clubs")
+@RequiredArgsConstructor
+@Tag(name = "Club ViewCount Test", description = "조회수 동시성 전략별 테스트 API")
+public class ClubViewCountTestController {
+
+    private final ClubViewCountTestService clubViewCountTestService;
+
+    @Operation(summary = "[테스트] Dirty Check")
+    @GetMapping("/{clubId}/dirty-check")
+    public ApiResponse<ClubDetailResponse> dirtyCheck(@PathVariable Long clubId) {
+        return ApiResponse.onSuccess(clubViewCountTestService.findClubDetailWithDirtyCheck(clubId));
+    }
+
+    @Operation(summary = "[테스트] Pessimistic Lock")
+    @GetMapping("/{clubId}/pessimistic-lock")
+    public ApiResponse<ClubDetailResponse> pessimisticLock(@PathVariable Long clubId) {
+        return ApiResponse.onSuccess(clubViewCountTestService.findClubDetailWithPessimisticLock(clubId));
+    }
+
+    @Operation(summary = "[테스트] Optimistic Lock")
+    @GetMapping("/{clubId}/optimistic-lock")
+    public ApiResponse<ClubDetailResponse> optimisticLock(@PathVariable Long clubId) {
+        return ApiResponse.onSuccess(clubViewCountTestService.findClubDetailWithOptimisticLock(clubId));
+    }
+
+    @Operation(summary = "[테스트] Atomic Operation (@Modifying)")
+    @GetMapping("/{clubId}/atomic")
+    public ApiResponse<ClubDetailResponse> atomicOperation(@PathVariable Long clubId) {
+        return ApiResponse.onSuccess(clubViewCountTestService.findClubDetailWithAtomicOperation(clubId));
+    }
+
+    @Operation(summary = "[테스트] Redis")
+    @GetMapping("/{clubId}/redis")
+    public ApiResponse<ClubDetailResponse> redis(@PathVariable Long clubId) {
+        return ApiResponse.onSuccess(clubViewCountTestService.findClubDetailWithRedis(clubId));
+    }
+}

--- a/src/main/java/kr/hanjari/backend/domain/club/presentation/dto/response/ClubDetailResponse.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/presentation/dto/response/ClubDetailResponse.java
@@ -1,5 +1,7 @@
 package kr.hanjari.backend.domain.club.presentation.dto.response;
 
+import kr.hanjari.backend.domain.club.domain.entity.Club;
+
 public record ClubDetailResponse(
     Long clubId,
     String description,
@@ -11,6 +13,19 @@ public record ClubDetailResponse(
     String applicationUrl
 
 ) {
+  public static ClubDetailResponse from(Club club) {
+    return new ClubDetailResponse(
+            club.getId(),
+            club.getDescription(),
+            club.getLeaderName(),
+            club.getLeaderPhone(),
+            club.getLeaderEmail(),
+            club.getMembershipFee(),
+            club.getSnsUrl(),
+            club.getApplicationUrl()
+    );
+  }
+
 
   public static ClubDetailResponse of(
       Long clubId,


### PR DESCRIPTION
## Changes
- `ClubRepository`: `findByIdWithPessimisticLock`, `incrementViewCountWithVersionCheck`, `incrementViewCount` 메서드 추가
- `Club`: optimistic lock 테스트용 `version` 필드 추가 (`@ColumnDefault("0")`)
- `ClubViewCountTestController` / `ClubViewCountTestService`: 5가지 동시성 전략 테스트 API 추가
  - dirty-check, pessimistic-lock, optimistic-lock, atomic, redis
- `ClubDetailResponse`: `from(Club)` 팩토리 메서드 추가

## Related Issue


## Check List
- [x] Local Test