### PR TITLE
[REFACTOR] Redis 기반 조회수 증가 및 periodic DB 동기화 적용

### DIFF
--- a/src/main/java/kr/hanjari/backend/domain/club/application/command/impl/ClubCommandServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/application/command/impl/ClubCommandServiceImpl.java
@@ -54,6 +54,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -68,6 +69,8 @@ public class ClubCommandServiceImpl implements ClubCommandService {
 
     @Value("${login.url}")
     private String loginURL;
+
+    private final StringRedisTemplate redisTemplate;
 
     private final FileRepository fileRepository;
     private final ClubRepository clubRepository;
@@ -359,10 +362,8 @@ public class ClubCommandServiceImpl implements ClubCommandService {
 
     @Override
     public void incrementClubViewCount(Long clubId) {
-//        Club club = getClub(clubId);
-        Club club = getClubWithXLock(clubId);
-        club.incrementViewCount();
-//        clubRepository.save(club);
+        String key = "club:viewCount:" + clubId;
+        redisTemplate.opsForValue().increment(key);
     }
 
     // ======= Private Methods ======= //

--- a/src/main/java/kr/hanjari/backend/domain/club/application/command/impl/ClubViewCountSyncScheduler.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/application/command/impl/ClubViewCountSyncScheduler.java
@@ -1,0 +1,50 @@
+package kr.hanjari.backend.domain.club.application.command.impl;
+
+import kr.hanjari.backend.domain.club.domain.repository.ClubRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ClubViewCountSyncScheduler {
+
+    private static final String KEY_PATTERN = "club:viewCount:*";
+
+    private final StringRedisTemplate redisTemplate;
+    private final ClubRepository clubRepository;
+
+    @Scheduled(fixedDelay = 60000) // 1분
+    @Transactional
+    public void syncViewCountToDb() {
+        Set<String> keys = redisTemplate.keys(KEY_PATTERN);
+        if (keys == null || keys.isEmpty()) {
+            return;
+        }
+
+        for (String key : keys) {
+            try {
+                String value = redisTemplate.opsForValue().getAndDelete(key);
+                if (value == null) continue;
+
+                long delta = Long.parseLong(value);
+                Long clubId = extractClubId(key);
+
+                clubRepository.incrementViewCountBy(clubId, delta);
+                log.info("[ViewCount Sync] clubId={}, delta={}", clubId, delta);
+            } catch (Exception e) {
+                log.error("[ViewCount Sync] failed for key={}", key, e);
+            }
+        }
+    }
+
+    private Long extractClubId(String key) {
+        return Long.parseLong(key.substring(key.lastIndexOf(":") + 1));
+    }
+}

--- a/src/main/java/kr/hanjari/backend/domain/club/application/query/impl/ClubQueryServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/application/query/impl/ClubQueryServiceImpl.java
@@ -131,15 +131,7 @@ public class ClubQueryServiceImpl implements ClubQueryService {
         clubCommandService.incrementClubViewCount(clubId);
         Club club = getClub(clubId);
 
-        return ClubDetailResponse.of(
-            club.getId(),
-            club.getDescription(),
-            club.getLeaderName(),
-            club.getLeaderPhone(),
-            club.getLeaderEmail(),
-            club.getMembershipFee(),
-            club.getSnsUrl(),
-            club.getApplicationUrl());
+        return ClubDetailResponse.from(club);
     }
 
     @Override

--- a/src/main/java/kr/hanjari/backend/domain/club/application/query/impl/ClubViewCountTestService.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/application/query/impl/ClubViewCountTestService.java
@@ -1,17 +1,15 @@
 package kr.hanjari.backend.domain.club.application.query.impl;
 
-import kr.hanjari.backend.domain.club.application.command.ClubCommandService;
 import kr.hanjari.backend.domain.club.domain.entity.Club;
 import kr.hanjari.backend.domain.club.domain.repository.ClubRepository;
 import kr.hanjari.backend.domain.club.presentation.dto.response.ClubDetailResponse;
-import kr.hanjari.backend.global.payload.code.status.ErrorStatus;
-import kr.hanjari.backend.global.payload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Profile({"local", "dev"})
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -34,16 +32,16 @@ public class ClubViewCountTestService {
         return getDTO(club);
     }
 
-    public ClubDetailResponse findClubDetailWithOptimisticLock(Long clubId) {
-        Club club = getClub(clubId);
-
-        int updated = clubRepository.incrementViewCountWithVersionCheck(clubId, club.getVersion());
-
-        if (updated == 0) {
-            throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
-        }
-        return getDTO(club);
-    }
+//    public ClubDetailResponse findClubDetailWithOptimisticLock(Long clubId) {
+//        Club club = getClub(clubId);
+//
+//        int updated = clubRepository.incrementViewCountWithVersionCheck(clubId, club.getVersion());
+//
+//        if (updated == 0) {
+//            throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
+//        }
+//        return getDTO(club);
+//    }
 
     public ClubDetailResponse findClubDetailWithAtomicOperation(Long clubId) {
         Club club = getClub(clubId);

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/entity/Club.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/entity/Club.java
@@ -26,7 +26,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @Entity
@@ -43,9 +42,6 @@ public class Club extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @ColumnDefault("0")
-    private Long version;
 
     @Column(name = "code")
     private String code;

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/repository/ClubRepository.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/repository/ClubRepository.java
@@ -21,9 +21,9 @@ public interface ClubRepository extends JpaRepository<Club, Long>, JpaSpecificat
     @Query("SELECT c FROM Club c WHERE c.id = :id")
     Optional<Club> findByIdWithPessimisticLock(Long id);
 
-    @Modifying
-    @Query("UPDATE Club c SET c.viewCount = c.viewCount + 1, c.version = c.version + 1 WHERE c.id = :id AND c.version = :version")
-    int incrementViewCountWithVersionCheck(Long id, Long version);
+//    @Modifying
+//    @Query("UPDATE Club c SET c.viewCount = c.viewCount + 1, c.version = c.version + 1 WHERE c.id = :id AND c.version = :version")
+//    int incrementViewCountWithVersionCheck(Long id, Long version);
 
     @Modifying
     @Query("UPDATE Club c SET c.viewCount = c.viewCount + 1 WHERE c.id = :id")

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/repository/ClubRepository.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/repository/ClubRepository.java
@@ -29,6 +29,10 @@ public interface ClubRepository extends JpaRepository<Club, Long>, JpaSpecificat
     @Query("UPDATE Club c SET c.viewCount = c.viewCount + 1 WHERE c.id = :id")
     int incrementViewCount(Long id);
 
+    @Modifying
+    @Query("UPDATE Club c SET c.viewCount = c.viewCount + :delta WHERE c.id = :id")
+    int incrementViewCountBy(Long id, Long delta);
+
     boolean existsByCode(String code);
 
     @Query("SELECT c FROM Club c WHERE (:name IS NULL OR c.name LIKE %:name%) " +

--- a/src/main/java/kr/hanjari/backend/domain/club/presentation/controller/ClubViewCountTestController.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/presentation/controller/ClubViewCountTestController.java
@@ -6,11 +6,13 @@ import kr.hanjari.backend.domain.club.application.query.impl.ClubViewCountTestSe
 import kr.hanjari.backend.domain.club.presentation.dto.response.ClubDetailResponse;
 import kr.hanjari.backend.global.payload.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Profile({"local", "dev"})
 @RestController
 @RequestMapping("/api/test/clubs")
 @RequiredArgsConstructor
@@ -31,11 +33,11 @@ public class ClubViewCountTestController {
         return ApiResponse.onSuccess(clubViewCountTestService.findClubDetailWithPessimisticLock(clubId));
     }
 
-    @Operation(summary = "[테스트] Optimistic Lock")
-    @GetMapping("/{clubId}/optimistic-lock")
-    public ApiResponse<ClubDetailResponse> optimisticLock(@PathVariable Long clubId) {
-        return ApiResponse.onSuccess(clubViewCountTestService.findClubDetailWithOptimisticLock(clubId));
-    }
+//    @Operation(summary = "[테스트] Optimistic Lock")
+//    @GetMapping("/{clubId}/optimistic-lock")
+//    public ApiResponse<ClubDetailResponse> optimisticLock(@PathVariable Long clubId) {
+//        return ApiResponse.onSuccess(clubViewCountTestService.findClubDetailWithOptimisticLock(clubId));
+//    }
 
     @Operation(summary = "[테스트] Atomic Operation (@Modifying)")
     @GetMapping("/{clubId}/atomic")


### PR DESCRIPTION
## Changes
- `ClubCommandServiceImpl`: 조회수 증가를 Redis INCR으로 변경
- `ClubViewCountSyncScheduler`: 1분마다 Redis → DB 동기화 scheduler 추가
- `ClubRepository`: `incrementViewCountBy` method 추가
- `Club`: test용 `version` 필드 제거
- `ClubViewCountTestController` / `ClubViewCountTestService`: `@Profile({"local", "dev"})` 적용

## Related Issue
Closes #180

## Check List
- [x] Local Test