### PR TITLE
[REFACTOR] 조회수 동기화 스케줄러 안정성 개선

### DIFF
--- a/adr/template/template.md
+++ b/adr/template/template.md
@@ -14,3 +14,9 @@ What other options were evaluated, and why were they not chosen?
 
 ## Consequences
 What becomes easier or more difficult to do because of this change?
+
+**Improvements** *(optional)*
+- ...
+
+**Known Issues / Trade-offs** *(optional)*
+- ...

--- a/adr/viewcount.md
+++ b/adr/viewcount.md
@@ -39,5 +39,6 @@ Redis INCR is a single-threaded atomic operation that guarantees concurrency wit
 1. **Up to 1-minute staleness**: `viewCount` in API responses is DB-based; unsynced Redis increments are not reflected for up to 1 minute
 2. **Data loss on server restart**: Redis increments not yet synced to DB are lost on restart; no Graceful Shutdown hook for forced sync
 3. **`KEYS` command performance**: `KEYS club:viewCount:*` is O(N) blocking; should be replaced with `SCAN`
+   - resolved: replaced with `SCAN` + cursor in `ClubViewCountSyncScheduler`
 4. **Data loss on Redis failure**: View counts recorded during Redis downtime are unrecoverable; no fallback to direct DB increment
 5. **Cold start**: Idle Redis connection pool causes first requests to stall on connection setup (0–14s outage observed on dev)

--- a/adr/viewcount.md
+++ b/adr/viewcount.md
@@ -38,7 +38,8 @@ Redis INCR is a single-threaded atomic operation that guarantees concurrency wit
 **Known Issues**
 1. **Up to 1-minute staleness**: `viewCount` in API responses is DB-based; unsynced Redis increments are not reflected for up to 1 minute
 2. **Data loss on server restart**: Redis increments not yet synced to DB are lost on restart; no Graceful Shutdown hook for forced sync
+   - resolved: added `@PreDestroy` flush (PR #185)
 3. **`KEYS` command performance**: `KEYS club:viewCount:*` is O(N) blocking; should be replaced with `SCAN`
-   - resolved: replaced with `SCAN` + cursor in `ClubViewCountSyncScheduler`
+   - resolved: replaced with `SCAN` + cursor in `ClubViewCountSyncScheduler` (PR #185)
 4. **Data loss on Redis failure**: View counts recorded during Redis downtime are unrecoverable; no fallback to direct DB increment
 5. **Cold start**: Idle Redis connection pool causes first requests to stall on connection setup (0–14s outage observed on dev)

--- a/src/main/java/kr/hanjari/backend/domain/club/application/command/impl/ClubViewCountSyncScheduler.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/application/command/impl/ClubViewCountSyncScheduler.java
@@ -3,11 +3,15 @@ package kr.hanjari.backend.domain.club.application.command.impl;
 import kr.hanjari.backend.domain.club.domain.repository.ClubRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.springframework.data.redis.core.ScanOptions;
+
+import java.util.HashSet;
 import java.util.Set;
 
 @Slf4j
@@ -23,8 +27,16 @@ public class ClubViewCountSyncScheduler {
     @Scheduled(fixedDelay = 60000) // 1분
     @Transactional
     public void syncViewCountToDb() {
-        Set<String> keys = redisTemplate.keys(KEY_PATTERN);
-        if (keys == null || keys.isEmpty()) {
+        Set<String> keys = new HashSet<>();
+        ScanOptions options = ScanOptions.scanOptions()
+                .match(KEY_PATTERN)
+                .count(100)
+                .build();
+
+        try (Cursor<String> cursor = redisTemplate.scan(options)) {
+            cursor.forEachRemaining(keys::add);
+        }
+        if (keys.isEmpty()) {
             return;
         }
 

--- a/src/main/java/kr/hanjari/backend/domain/club/application/command/impl/ClubViewCountSyncScheduler.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/application/command/impl/ClubViewCountSyncScheduler.java
@@ -3,6 +3,7 @@ package kr.hanjari.backend.domain.club.application.command.impl;
 import kr.hanjari.backend.domain.club.domain.repository.ClubRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import jakarta.annotation.PreDestroy;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -54,6 +55,13 @@ public class ClubViewCountSyncScheduler {
                 log.error("[ViewCount Sync] failed for key={}", key, e);
             }
         }
+    }
+
+    @PreDestroy
+    @Transactional
+    public void flushOnShutdown() {
+        log.info("[ViewCount Sync] Graceful shutdown triggered — flushing view counts");
+        syncViewCountToDb();
     }
 
     private Long extractClubId(String key) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -58,6 +58,10 @@ union.admin=${UNION_ADMIN}
 server.port=8080
 server.ssl.enabled=false
 
+# Graceful Shutdown
+server.shutdown=graceful
+spring.lifecycle.timeout-per-shutdown-phase=30s
+
 # SELENIUM
 #selenium.url=${SELENIUM_URL}
 


### PR DESCRIPTION
## Changes
- `KEYS`(O(N)) → `SCAN` cursor 방식으로 교체 (`ClubViewCountSyncScheduler`)
- 서버 종료 시 미동기화 조회수 flush

## Related Issue
Closes #180

## Check List
- [x] Local Test