### PR TITLE
[REFACTOR] 동아리 목록 조회 쿼리 최적화

### DIFF
--- a/src/main/java/kr/hanjari/backend/domain/club/application/query/impl/ClubQueryServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/application/query/impl/ClubQueryServiceImpl.java
@@ -29,7 +29,7 @@ import kr.hanjari.backend.domain.club.domain.repository.draft.IntroductionDraftR
 import kr.hanjari.backend.domain.club.domain.repository.draft.RecruitmentDraftRepository;
 import kr.hanjari.backend.domain.club.domain.repository.draft.ScheduleDescriptionDraftRepository;
 import kr.hanjari.backend.domain.club.domain.repository.draft.ScheduleDraftRepository;
-import kr.hanjari.backend.domain.club.domain.repository.search.ClubSearchProjection;
+import kr.hanjari.backend.domain.club.domain.repository.search.projection.ClubSearchProjection;
 import kr.hanjari.backend.domain.club.domain.repository.search.ClubSearchRepository;
 import kr.hanjari.backend.domain.club.domain.repository.search.ClubSpecifications;
 import kr.hanjari.backend.domain.club.presentation.dto.response.*;
@@ -374,7 +374,7 @@ public class ClubQueryServiceImpl implements ClubQueryService {
     }
 
     private String resolveImageUrlByKey(String key) {
-        return s3Service.getDownloadUrl(key);
+        return key == null ? null : s3Service.getDownloadUrl(key);
     }
 
 
@@ -447,41 +447,34 @@ public class ClubQueryServiceImpl implements ClubQueryService {
 
     @Override
     public GetInstagrams findInstagramsCentral(CentralClubCategory category, int page, int size) {
-
-        Page<Club> clubs = clubSearchRepository.findCentralClubsByCondition(
+        Page<ClubSearchProjection> projections = clubSearchRepository.findCentralClubsAsProjection(
                 null, null, null, category, true, page, size);
 
-        return getGetInstagramsDTO(clubs);
+        return getGetInstagramsDTOFromProjection(projections);
     }
 
     @Override
     public GetInstagrams findInstagramsUnion(UnionClubCategory category, int page, int size) {
+        Page<ClubSearchProjection> projections = clubSearchRepository.findUnionClubsAsProjection(
+                null, null, null, category, true, page, size);
 
-        Page<Club> clubs = clubSearchRepository.findUnionClubsByCondition(
-                null, null, null, category, true, page, size
-        );
-
-        return getGetInstagramsDTO(clubs);
+        return getGetInstagramsDTOFromProjection(projections);
     }
 
     @Override
     public GetInstagrams findInstagramsCollege(College college, int page, int size) {
+        Page<ClubSearchProjection> projections = clubSearchRepository.findCollegeClubsAsProjection(
+                null, null, null, college, true, page, size);
 
-        Page<Club> clubs = clubSearchRepository.findCollegeClubsByCondition(
-                null, null, null, college, true, page, size
-        );
-
-        return getGetInstagramsDTO(clubs);
+        return getGetInstagramsDTOFromProjection(projections);
     }
 
     @Override
     public GetInstagrams findInstagramsDepartment(Department department, int page, int size) {
+        Page<ClubSearchProjection> projections = clubSearchRepository.findDepartmentClubsAsProjection(
+                null, null, null, null, department, true, page, size);
 
-        Page<Club> clubs = clubSearchRepository.findDepartmentClubsByCondition(
-                null, null, null, null, department, true, page, size
-        );
-
-        return getGetInstagramsDTO(clubs);
+        return getGetInstagramsDTOFromProjection(projections);
     }
 
     @Override
@@ -498,9 +491,12 @@ public class ClubQueryServiceImpl implements ClubQueryService {
         return GetInstagramsMain.of(dtoList);
     }
     private GetInstagrams getGetInstagramsDTO(Page<Club> clubs) {
-
         Page<ClubInstagramDTO> dtoPage = clubs.map(this::getClubInstagramDTO);
+        return GetInstagrams.from(dtoPage);
+    }
 
+    private GetInstagrams getGetInstagramsDTOFromProjection(Page<ClubSearchProjection> projections) {
+        Page<ClubInstagramDTO> dtoPage = projections.map(this::getClubInstagramDTOFromProjection);
         return GetInstagrams.from(dtoPage);
     }
 
@@ -510,5 +506,11 @@ public class ClubQueryServiceImpl implements ClubQueryService {
         String profileImageUrl = resolveImageUrl(club);
         String profileUrl = INSTAGRAM_URL + account;
         return ClubInstagramDTO.of(clubName, account, profileImageUrl, profileUrl);
+    }
+
+    private ClubInstagramDTO getClubInstagramDTOFromProjection(ClubSearchProjection p) {
+        String profileImageUrl = p.fileKey() != null ? resolveImageUrlByKey(p.fileKey()) : null;
+        String profileUrl = INSTAGRAM_URL + p.snsUrl();
+        return ClubInstagramDTO.of(p.name(), p.snsUrl(), profileImageUrl, profileUrl);
     }
 }

--- a/src/main/java/kr/hanjari/backend/domain/club/application/query/impl/ClubQueryServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/application/query/impl/ClubQueryServiceImpl.java
@@ -225,29 +225,29 @@ public class ClubQueryServiceImpl implements ClubQueryService {
     @Override
     public ClubSearchResponse findUnionClubsByCondition(String keyword, RecruitmentStatus status, SortBy sortBy,
                                                         UnionClubCategory unionCategory, int page, int size) {
-        Page<Club> clubs = clubSearchRepository.findUnionClubsByCondition(
+        Page<ClubSearchProjection> projections = clubSearchRepository.findUnionClubsAsProjection(
                 keyword, status, sortBy, unionCategory, false, page, size);
 
-        return getClubSearchResponseDTO(clubs);
+        return getClubSearchResponseFromProjection(projections);
     }
 
     @Override
     public ClubSearchResponse findCollegeClubsByCondition(String keyword, RecruitmentStatus status, SortBy sortBy,
                                                           College college, int page, int size) {
-        Page<Club> clubs = clubSearchRepository.findCollegeClubsByCondition(
+        Page<ClubSearchProjection> projections = clubSearchRepository.findCollegeClubsAsProjection(
                 keyword, status, sortBy, college, false, page, size);
 
-        return getClubSearchResponseDTO(clubs);
+        return getClubSearchResponseFromProjection(projections);
     }
 
     @Override
     public ClubSearchResponse findDepartmentClubsByCondition(String keyword, RecruitmentStatus status, SortBy sortBy,
                                                              College college, Department department, int page,
                                                              int size) {
-        Page<Club> clubs = clubSearchRepository.findDepartmentClubsByCondition(
+        Page<ClubSearchProjection> projections = clubSearchRepository.findDepartmentClubsAsProjection(
                 keyword, status, sortBy, college, department, false, page, size);
 
-        return getClubSearchResponseDTO(clubs);
+        return getClubSearchResponseFromProjection(projections);
     }
 
     @Override

--- a/src/main/java/kr/hanjari/backend/domain/club/application/query/impl/ClubQueryServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/application/query/impl/ClubQueryServiceImpl.java
@@ -29,6 +29,7 @@ import kr.hanjari.backend.domain.club.domain.repository.draft.IntroductionDraftR
 import kr.hanjari.backend.domain.club.domain.repository.draft.RecruitmentDraftRepository;
 import kr.hanjari.backend.domain.club.domain.repository.draft.ScheduleDescriptionDraftRepository;
 import kr.hanjari.backend.domain.club.domain.repository.draft.ScheduleDraftRepository;
+import kr.hanjari.backend.domain.club.domain.repository.search.ClubSearchProjection;
 import kr.hanjari.backend.domain.club.domain.repository.search.ClubSearchRepository;
 import kr.hanjari.backend.domain.club.domain.repository.search.ClubSpecifications;
 import kr.hanjari.backend.domain.club.presentation.dto.response.*;
@@ -215,10 +216,10 @@ public class ClubQueryServiceImpl implements ClubQueryService {
     public ClubSearchResponse findCentralClubsByCondition(String keyword, RecruitmentStatus status, SortBy sortBy,
                                                           CentralClubCategory centralClubCategory, int page,
                                                           int size) {
-        Page<Club> clubs = clubSearchRepository.findCentralClubsByCondition(
+        Page<ClubSearchProjection> projections = clubSearchRepository.findCentralClubsAsProjection(
                 keyword, status, sortBy, centralClubCategory, false, page, size);
 
-        return getClubSearchResponseDTO(clubs);
+        return getClubSearchResponseFromProjection(projections);
     }
 
     @Override
@@ -372,7 +373,26 @@ public class ClubQueryServiceImpl implements ClubQueryService {
         return s3Service.getDownloadUrl(clubRegistration.getImageFile().getId());
     }
 
+    private String resolveImageUrlByKey(String key) {
+        return s3Service.getDownloadUrl(key);
+    }
 
+
+
+    private ClubSearchResponse getClubSearchResponseFromProjection(Page<ClubSearchProjection> projections) {
+        Page<ClubSearchResult> dtoPage = projections.map(p ->
+                ClubSearchResult.of(
+                        p.clubId(),
+                        p.name(),
+                        p.oneLiner(),
+                        resolveImageUrlByKey(p.fileKey()),
+                        p.clubType().getDescription(),
+                        p.recruitmentStatus(),
+                        p.getTag()
+                )
+        );
+        return ClubSearchResponse.of(dtoPage);
+    }
 
     private ClubSearchResponse getClubSearchResponseDTO(Page<Club> clubs) {
         Page<ClubSearchResult> dtoPage = clubs.map(club ->

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/ClubSearchProjection.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/ClubSearchProjection.java
@@ -1,0 +1,30 @@
+package kr.hanjari.backend.domain.club.domain.repository.search;
+
+import kr.hanjari.backend.domain.club.domain.enums.CentralClubCategory;
+import kr.hanjari.backend.domain.club.domain.enums.ClubType;
+import kr.hanjari.backend.domain.club.domain.enums.College;
+import kr.hanjari.backend.domain.club.domain.enums.Department;
+import kr.hanjari.backend.domain.club.domain.enums.RecruitmentStatus;
+import kr.hanjari.backend.domain.club.domain.enums.UnionClubCategory;
+
+public record ClubSearchProjection(
+        Long clubId,
+        String name,
+        String oneLiner,
+        String fileKey,
+        ClubType clubType,
+        CentralClubCategory centralCategory,
+        UnionClubCategory unionCategory,
+        College college,
+        Department department,
+        RecruitmentStatus recruitmentStatus
+) {
+    public String getTag() {
+        return switch (clubType) {
+            case CENTRAL -> centralCategory != null ? centralCategory.toString() : "Unknown";
+            case UNION -> unionCategory != null ? unionCategory.toString() : "Unknown";
+            case COLLEGE -> college != null ? college.toString() : "Unknown";
+            case DEPARTMENT -> department != null ? department.toString() : "Unknown";
+        };
+    }
+}

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/ClubSearchRepository.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/ClubSearchRepository.java
@@ -2,6 +2,7 @@ package kr.hanjari.backend.domain.club.domain.repository.search;
 
 import kr.hanjari.backend.domain.club.domain.entity.Club;
 import kr.hanjari.backend.domain.club.domain.enums.*;
+import kr.hanjari.backend.domain.club.domain.repository.search.projection.ClubSearchProjection;
 import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/ClubSearchRepository.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/ClubSearchRepository.java
@@ -21,11 +21,23 @@ public interface ClubSearchRepository {
             String keyword, RecruitmentStatus status, SortBy sortBy,
             UnionClubCategory category, boolean onlyWithSns, int page, int size);
 
+    Page<ClubSearchProjection> findUnionClubsAsProjection(
+            String keyword, RecruitmentStatus status, SortBy sortBy,
+            UnionClubCategory category, boolean onlyWithSns, int page, int size);
+
     Page<Club> findCollegeClubsByCondition(
             String keyword, RecruitmentStatus status, SortBy sortBy,
             College college, boolean onlyWithSns, int page, int size);
 
+    Page<ClubSearchProjection> findCollegeClubsAsProjection(
+            String keyword, RecruitmentStatus status, SortBy sortBy,
+            College college, boolean onlyWithSns, int page, int size);
+
     Page<Club> findDepartmentClubsByCondition(
+            String keyword, RecruitmentStatus status, SortBy sortBy,
+            College college, Department departmentName, boolean onlyWithSns, int page, int size);
+
+    Page<ClubSearchProjection> findDepartmentClubsAsProjection(
             String keyword, RecruitmentStatus status, SortBy sortBy,
             College college, Department departmentName, boolean onlyWithSns, int page, int size);
 

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/ClubSearchRepository.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/ClubSearchRepository.java
@@ -13,6 +13,10 @@ public interface ClubSearchRepository {
             String keyword, RecruitmentStatus status, SortBy sortBy,
             CentralClubCategory category, boolean onlyWithSns, int page, int size);
 
+    Page<ClubSearchProjection> findCentralClubsAsProjection(
+            String keyword, RecruitmentStatus status, SortBy sortBy,
+            CentralClubCategory category, boolean onlyWithSns, int page, int size);
+
     Page<Club> findUnionClubsByCondition(
             String keyword, RecruitmentStatus status, SortBy sortBy,
             UnionClubCategory category, boolean onlyWithSns, int page, int size);

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/impl/ClubSearchRepositoryImpl.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/impl/ClubSearchRepositoryImpl.java
@@ -3,6 +3,7 @@ package kr.hanjari.backend.domain.club.domain.repository.search.impl;
 import static org.springframework.data.domain.PageRequest.of;
 
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -10,6 +11,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import kr.hanjari.backend.domain.club.domain.entity.Club;
 import kr.hanjari.backend.domain.club.domain.entity.QClub;
+import kr.hanjari.backend.domain.club.domain.repository.search.ClubSearchProjection;
+import kr.hanjari.backend.domain.file.domain.entity.QFile;
 import kr.hanjari.backend.domain.club.domain.enums.CentralClubCategory;
 import kr.hanjari.backend.domain.club.domain.enums.ClubType;
 import kr.hanjari.backend.domain.club.domain.enums.College;
@@ -57,6 +60,52 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                 .fetchOne();
 
         return new PageImpl<>(clubs, of(page, size), getTotal(totalElements));
+    }
+
+    @Override
+    public Page<ClubSearchProjection> findCentralClubsAsProjection(
+            String keyword, RecruitmentStatus status, SortBy sortBy,
+            CentralClubCategory category, boolean onlyWithSns, int page, int size) {
+        QClub club = QClub.club;
+        QFile file = QFile.file;
+
+        List<ClubSearchProjection> results = query
+                .select(Projections.constructor(ClubSearchProjection.class,
+                        club.id,
+                        club.name,
+                        club.oneLiner,
+                        file.fileKey,
+                        club.categoryInfo.clubType,
+                        club.categoryInfo.centralCategory,
+                        club.categoryInfo.unionCategory,
+                        club.categoryInfo.college,
+                        club.categoryInfo.department,
+                        club.recruitmentStatus
+                ))
+                .from(club)
+                .leftJoin(club.imageFile, file)
+                .where(
+                        club.categoryInfo.clubType.eq(ClubType.CENTRAL),
+                        nameContains(keyword),
+                        statusEq(status),
+                        centralCategoryEq(category),
+                        snsFieldCheck(onlyWithSns))
+                .orderBy(getOrderSpecifier(sortBy))
+                .offset((long) page * size)
+                .limit(size)
+                .fetch();
+
+        Long totalElements = query.select(club.count())
+                .from(club)
+                .where(
+                        club.categoryInfo.clubType.eq(ClubType.CENTRAL),
+                        nameContains(keyword),
+                        statusEq(status),
+                        centralCategoryEq(category),
+                        snsFieldCheck(onlyWithSns))
+                .fetchOne();
+
+        return new PageImpl<>(results, of(page, size), getTotal(totalElements));
     }
 
     @Override

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/impl/ClubSearchRepositoryImpl.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/impl/ClubSearchRepositoryImpl.java
@@ -109,6 +109,52 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
     }
 
     @Override
+    public Page<ClubSearchProjection> findUnionClubsAsProjection(
+            String keyword, RecruitmentStatus status, SortBy sortBy,
+            UnionClubCategory category, boolean onlyWithSns, int page, int size) {
+        QClub club = QClub.club;
+        QFile file = QFile.file;
+
+        List<ClubSearchProjection> results = query
+                .select(Projections.constructor(ClubSearchProjection.class,
+                        club.id,
+                        club.name,
+                        club.oneLiner,
+                        file.fileKey,
+                        club.categoryInfo.clubType,
+                        club.categoryInfo.centralCategory,
+                        club.categoryInfo.unionCategory,
+                        club.categoryInfo.college,
+                        club.categoryInfo.department,
+                        club.recruitmentStatus
+                ))
+                .from(club)
+                .leftJoin(club.imageFile, file)
+                .where(
+                        club.categoryInfo.clubType.eq(ClubType.UNION),
+                        nameContains(keyword),
+                        statusEq(status),
+                        unionCategoryEq(category),
+                        snsFieldCheck(onlyWithSns))
+                .orderBy(getOrderSpecifier(sortBy))
+                .offset((long) page * size)
+                .limit(size)
+                .fetch();
+
+        Long totalElements = query.select(club.count())
+                .from(club)
+                .where(
+                        club.categoryInfo.clubType.eq(ClubType.UNION),
+                        nameContains(keyword),
+                        statusEq(status),
+                        unionCategoryEq(category),
+                        snsFieldCheck(onlyWithSns))
+                .fetchOne();
+
+        return new PageImpl<>(results, of(page, size), getTotal(totalElements));
+    }
+
+    @Override
     public Page<Club> findUnionClubsByCondition(String keyword, RecruitmentStatus status, SortBy sortBy,
                                                 UnionClubCategory category, boolean onlyWithSns, int page, int size) {
         QClub club = QClub.club;
@@ -140,6 +186,52 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
     }
 
     @Override
+    public Page<ClubSearchProjection> findCollegeClubsAsProjection(
+            String keyword, RecruitmentStatus status, SortBy sortBy,
+            College college, boolean onlyWithSns, int page, int size) {
+        QClub club = QClub.club;
+        QFile file = QFile.file;
+
+        List<ClubSearchProjection> results = query
+                .select(Projections.constructor(ClubSearchProjection.class,
+                        club.id,
+                        club.name,
+                        club.oneLiner,
+                        file.fileKey,
+                        club.categoryInfo.clubType,
+                        club.categoryInfo.centralCategory,
+                        club.categoryInfo.unionCategory,
+                        club.categoryInfo.college,
+                        club.categoryInfo.department,
+                        club.recruitmentStatus
+                ))
+                .from(club)
+                .leftJoin(club.imageFile, file)
+                .where(
+                        club.categoryInfo.clubType.eq(ClubType.COLLEGE),
+                        nameContains(keyword),
+                        statusEq(status),
+                        collegeEq(college),
+                        snsFieldCheck(onlyWithSns))
+                .orderBy(getOrderSpecifier(sortBy))
+                .offset((long) page * size)
+                .limit(size)
+                .fetch();
+
+        Long totalElements = query.select(club.count())
+                .from(club)
+                .where(
+                        club.categoryInfo.clubType.eq(ClubType.COLLEGE),
+                        nameContains(keyword),
+                        statusEq(status),
+                        collegeEq(college),
+                        snsFieldCheck(onlyWithSns))
+                .fetchOne();
+
+        return new PageImpl<>(results, of(page, size), getTotal(totalElements));
+    }
+
+    @Override
     public Page<Club> findCollegeClubsByCondition(String keyword, RecruitmentStatus status, SortBy sortBy,
                                                   College college, boolean onlyWithSns, int page, int size) {
         QClub club = QClub.club;
@@ -168,6 +260,54 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                 .fetchOne();
 
         return new PageImpl<>(clubs, of(page, size), getTotal(totalElement));
+    }
+
+    @Override
+    public Page<ClubSearchProjection> findDepartmentClubsAsProjection(
+            String keyword, RecruitmentStatus status, SortBy sortBy,
+            College college, Department departmentName, boolean onlyWithSns, int page, int size) {
+        QClub club = QClub.club;
+        QFile file = QFile.file;
+
+        List<ClubSearchProjection> results = query
+                .select(Projections.constructor(ClubSearchProjection.class,
+                        club.id,
+                        club.name,
+                        club.oneLiner,
+                        file.fileKey,
+                        club.categoryInfo.clubType,
+                        club.categoryInfo.centralCategory,
+                        club.categoryInfo.unionCategory,
+                        club.categoryInfo.college,
+                        club.categoryInfo.department,
+                        club.recruitmentStatus
+                ))
+                .from(club)
+                .leftJoin(club.imageFile, file)
+                .where(
+                        club.categoryInfo.clubType.eq(ClubType.DEPARTMENT),
+                        nameContains(keyword),
+                        statusEq(status),
+                        collegeEq(college),
+                        departmentEq(departmentName),
+                        snsFieldCheck(onlyWithSns))
+                .orderBy(getOrderSpecifier(sortBy))
+                .offset((long) page * size)
+                .limit(size)
+                .fetch();
+
+        Long totalElements = query.select(club.count())
+                .from(club)
+                .where(
+                        club.categoryInfo.clubType.eq(ClubType.DEPARTMENT),
+                        nameContains(keyword),
+                        statusEq(status),
+                        collegeEq(college),
+                        departmentEq(departmentName),
+                        snsFieldCheck(onlyWithSns))
+                .fetchOne();
+
+        return new PageImpl<>(results, of(page, size), getTotal(totalElements));
     }
 
     @Override

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/impl/ClubSearchRepositoryImpl.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/impl/ClubSearchRepositoryImpl.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import kr.hanjari.backend.domain.club.domain.entity.Club;
 import kr.hanjari.backend.domain.club.domain.entity.QClub;
-import kr.hanjari.backend.domain.club.domain.repository.search.ClubSearchProjection;
+import kr.hanjari.backend.domain.club.domain.repository.search.projection.ClubSearchProjection;
 import kr.hanjari.backend.domain.file.domain.entity.QFile;
 import kr.hanjari.backend.domain.club.domain.enums.CentralClubCategory;
 import kr.hanjari.backend.domain.club.domain.enums.ClubType;
@@ -80,7 +80,8 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                         club.categoryInfo.unionCategory,
                         club.categoryInfo.college,
                         club.categoryInfo.department,
-                        club.recruitmentStatus
+                        club.recruitmentStatus,
+                        club.snsUrl
                 ))
                 .from(club)
                 .leftJoin(club.imageFile, file)
@@ -126,7 +127,8 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                         club.categoryInfo.unionCategory,
                         club.categoryInfo.college,
                         club.categoryInfo.department,
-                        club.recruitmentStatus
+                        club.recruitmentStatus,
+                        club.snsUrl
                 ))
                 .from(club)
                 .leftJoin(club.imageFile, file)
@@ -203,7 +205,8 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                         club.categoryInfo.unionCategory,
                         club.categoryInfo.college,
                         club.categoryInfo.department,
-                        club.recruitmentStatus
+                        club.recruitmentStatus,
+                        club.snsUrl
                 ))
                 .from(club)
                 .leftJoin(club.imageFile, file)
@@ -280,7 +283,8 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                         club.categoryInfo.unionCategory,
                         club.categoryInfo.college,
                         club.categoryInfo.department,
-                        club.recruitmentStatus
+                        club.recruitmentStatus,
+                        club.snsUrl
                 ))
                 .from(club)
                 .leftJoin(club.imageFile, file)

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/projection/ClubSearchProjection.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/projection/ClubSearchProjection.java
@@ -1,4 +1,4 @@
-package kr.hanjari.backend.domain.club.domain.repository.search;
+package kr.hanjari.backend.domain.club.domain.repository.search.projection;
 
 import kr.hanjari.backend.domain.club.domain.enums.CentralClubCategory;
 import kr.hanjari.backend.domain.club.domain.enums.ClubType;
@@ -17,7 +17,8 @@ public record ClubSearchProjection(
         UnionClubCategory unionCategory,
         College college,
         Department department,
-        RecruitmentStatus recruitmentStatus
+        RecruitmentStatus recruitmentStatus,
+        String snsUrl
 ) {
     public String getTag() {
         return switch (clubType) {


### PR DESCRIPTION
## Changes
- ClubSearchProjection 레코드 추가 (club + file.fileKey 필드 포함)
- ClubSearchProjection에 snsUrl 필드 추가
- central, union, college, department 동아리 검색, 인스타그램 조회 메소드에 DTO projection 적용으로 1+N 제거
- JOIN 조건을 id 비교(.on(club.imageFile.id.eq(file.id)))로 작성 시 추가 쿼리 발생하기에 연관관계 조인 방식(leftJoin(club.imageFile, file))으로 작성 
- throughput 34.52/s -> 59.66/s (+73%)

## Related Issue
Closes #186

## Check List
- [x] Local Test