### PR TITLE
[FEAT] 태그 도메인 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# Hanjari
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This project is Club Information Platform of Hanyang University ERICA
 
 ## Build & Run Commands
 
@@ -10,29 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 # Run all tests
 ./gradlew test
-
-# Run a single test class
-./gradlew test --tests kr.hanjari.backend.domain.club.application.query.impl.ClubQueryServiceImplTest
-
-# Run a single test method
-./gradlew test --tests "kr.hanjari.backend.domain.club.ClubTest.someMethod"
 ```
-
-## Required Environment Variables
-
-The app requires these env vars (typically set in `.env`):
-
-| Variable | Purpose |
-|----------|---------|
-| `PROFILE` | Active Spring profile (`local`, `dev`, `prod`) |
-| `MYSQL_URL`, `MYSQL_USERNAME`, `MYSQL_PASSWORD` | Database connection |
-| `JPA_DDL` | Hibernate ddl-auto (`create`, `update`, `validate`, `none`) |
-| `AWS_REGION`, `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`, `S3_BUCKET_NAME` | S3 file storage |
-| `REDIS_HOST`, `REDIS_PORT` | Redis cache |
-| `MAIL_USERNAME`, `MAIL_PASSWORD` | Gmail SMTP |
-| `JWT_SECRET_KEY`, `JWT_EXPIRATION_TIME` | JWT authentication |
-| `LOGIN_URL`, `SERVICE_ADMIN`, `UNION_ADMIN` | Auth configuration |
-| `SLACK_WEBHOOK_URL` | Slack notifications |
 
 ## Architecture
 
@@ -77,22 +55,7 @@ club/
 - **BaseEntity**: All entities extend `BaseEntity` which provides `createdAt` / `updatedAt` via JPA auditing
 - **Global API response**: Standardized via `global/payload/` (response wrapper + error codes)
 - **Global exception handling**: `ExceptionAdvice` maps domain exceptions to HTTP responses
-
-### Infrastructure Layer
-
-- **JWT**: Stateless authentication; filter registered in `SecurityConfig`
-- **S3**: File uploads via Spring Cloud AWS
-- **Redis**: Caching
-- **Slack**: Webhook-based notifications
-- **Crawl**: Web crawler (used for club data)
-
-### Environment-specific Config
-
-- `application-local.properties` — local dev with local AWS credentials
-- `application-dev.properties` — dev server AWS credentials
-- `application-prod.properties` — production (Swagger disabled, stricter logging)
-
-CORS and Swagger behavior differ per profile (`DevCorsConfig` vs `ProdCorsConfig`; Swagger disabled in prod).
+- **Error Code**: 'ErrorStatus' contains Error type and messages
 
 ## Database
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 This project is Club Information Platform of Hanyang University ERICA
 
+## Tech Stack
+
+- **Java 21**, **Spring Boot 3.4.1** (Jakarta EE — use `jakarta.*` imports, not `javax.*`)
+- **QueryDSL 5.1.0** (jakarta variant)
+- **MySQL 8+**, **Redis**, **AWS S3**
+
 ## Build & Run Commands
 
 ```bash
@@ -55,7 +61,32 @@ club/
 - **BaseEntity**: All entities extend `BaseEntity` which provides `createdAt` / `updatedAt` via JPA auditing
 - **Global API response**: Standardized via `global/payload/` (response wrapper + error codes)
 - **Global exception handling**: `ExceptionAdvice` maps domain exceptions to HTTP responses
-- **Error Code**: 'ErrorStatus' contains Error type and messages
+- **Error Code**: `ErrorStatus` enum contains error type and message; domain-specific codes use `<DOMAIN><HTTP_STATUS>` format (e.g., `CLUB404`)
+
+### Exception Handling
+
+All business exceptions extend `GeneralException` wrapping an `ErrorStatus`:
+```
+throw new GeneralException(ErrorStatus._CLUB_NOT_FOUND);
+```
+
+### DTO Conventions
+
+- **Response DTOs**: Java `record` types with `@Schema` annotations for Swagger
+- **Request DTOs**: Jakarta Validation annotations (`@NotBlank`, `@NotNull`, `@Email`)
+- Static factory methods (`of()`, `from()`) to convert from entities or query results
+
+### Custom Repository Pattern
+
+QueryDSL repositories follow `CustomRepository` interface + `CustomRepositoryImpl` convention:
+
+```
+club/domain/repository/
+├── ClubSearchRepository.java         # interface
+└── ClubSearchRepositoryImpl.java     # @Repository, uses JPAQueryFactory
+```
+
+Use `Projections.constructor()` to fetch specific columns as projection records instead of full entities.
 
 ## Database
 

--- a/src/main/java/kr/hanjari/backend/domain/activity/presentation/controller/ActivityController.java
+++ b/src/main/java/kr/hanjari/backend/domain/activity/presentation/controller/ActivityController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+@Deprecated
 @RestController
 @RequestMapping("/api/activities")
 @RequiredArgsConstructor

--- a/src/main/java/kr/hanjari/backend/domain/announcement/presentation/controller/AnnouncementController.java
+++ b/src/main/java/kr/hanjari/backend/domain/announcement/presentation/controller/AnnouncementController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+@Deprecated
 @RestController
 @RequestMapping("/api/announcements")
 @RequiredArgsConstructor

--- a/src/main/java/kr/hanjari/backend/domain/club/application/query/ClubQueryService.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/application/query/ClubQueryService.java
@@ -21,8 +21,7 @@ public interface ClubQueryService {
 
     // 조건 별 동아리 검색
     ClubDetailListResponse findClubsByCondition(
-            String name, CentralClubCategory category, RecruitmentStatus status, SortBy sortBy, int page,
-            int size);
+            String name, CentralClubCategory category, Long tagId, SortBy sortBy, int page, int size);
 
     // 동아리 상세 조회
     ClubDetailResponse findClubDetail(Long clubId);
@@ -52,18 +51,16 @@ public interface ClubQueryService {
 
     // 동아리 카테고리 조회
     ClubSearchResponse findCentralClubsByCondition(
-            String keyword, RecruitmentStatus status, SortBy sortBy, CentralClubCategory category, int page, int size);
+            String keyword, Long tagId, SortBy sortBy, CentralClubCategory category, int page, int size);
 
     ClubSearchResponse findUnionClubsByCondition(
-            String keyword, RecruitmentStatus status, SortBy sortBy, UnionClubCategory unionCategory, int page,
-            int size);
+            String keyword, Long tagId, SortBy sortBy, UnionClubCategory unionCategory, int page, int size);
 
     ClubSearchResponse findCollegeClubsByCondition(
-            String keyword, RecruitmentStatus status, SortBy sortBy, College college, int page, int size);
+            String keyword, Long tagId, SortBy sortBy, College college, int page, int size);
 
     ClubSearchResponse findDepartmentClubsByCondition(
-            String keyword, RecruitmentStatus status, SortBy sortBy, College college, Department department, int page,
-            int size);
+            String keyword, Long tagId, SortBy sortBy, College college, Department department, int page, int size);
 
     // 현재 인기있는 동아리 조회
     ClubSearchResponse findPopularClubs(int page, int size);

--- a/src/main/java/kr/hanjari/backend/domain/club/application/query/impl/ClubQueryServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/application/query/impl/ClubQueryServiceImpl.java
@@ -3,7 +3,10 @@ package kr.hanjari.backend.domain.club.application.query.impl;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import kr.hanjari.backend.domain.club.application.command.ClubCommandService;
 import kr.hanjari.backend.domain.club.application.query.ClubQueryService;
 import kr.hanjari.backend.domain.club.domain.entity.Club;
@@ -40,6 +43,8 @@ import kr.hanjari.backend.domain.club.presentation.dto.response.draft.ClubDetail
 import kr.hanjari.backend.domain.club.presentation.dto.response.draft.ClubIntroductionDraftResponse;
 import kr.hanjari.backend.domain.club.presentation.dto.response.draft.ClubRecruitmentDraftResponse;
 import kr.hanjari.backend.domain.club.presentation.dto.response.draft.ClubScheduleDraftResponse;
+import kr.hanjari.backend.domain.tag.domain.entity.ClubTag;
+import kr.hanjari.backend.domain.tag.domain.repository.ClubTagRepository;
 import kr.hanjari.backend.global.payload.code.status.ErrorStatus;
 import kr.hanjari.backend.global.payload.exception.GeneralException;
 import kr.hanjari.backend.infrastructure.s3.S3Service;
@@ -80,6 +85,7 @@ public class ClubQueryServiceImpl implements ClubQueryService {
     private final ScheduleDescriptionDraftRepository scheduleDescriptionDraftRepository;
 
     private final ClubSearchRepository clubSearchRepository;
+    private final ClubTagRepository clubTagRepository;
 
     private final S3Service s3Service;
     private final ClubCommandService clubCommandService;
@@ -138,13 +144,15 @@ public class ClubQueryServiceImpl implements ClubQueryService {
     @Override
     public ClubOverviewResponse findClubOverview(Long clubId) {
         Club club = getClub(clubId);
-        return ClubOverviewResponse.of(club, s3Service.getDownloadUrl(club.getImageFile().getId()));
+        List<String> tags = getTagsForClub(clubId);
+        return ClubOverviewResponse.of(club, s3Service.getDownloadUrl(club.getImageFile().getId()), tags);
     }
 
     @Override
     public ClubAdminDetailResponse findClubAdminDetail(Long clubId) {
         Club club = getClub(clubId);
-        return ClubAdminDetailResponse.of(club, s3Service.getDownloadUrl(club.getImageFile().getId()));
+        List<String> tags = getTagsForClub(clubId);
+        return ClubAdminDetailResponse.of(club, s3Service.getDownloadUrl(club.getImageFile().getId()), tags);
     }
 
     @Override
@@ -192,9 +200,10 @@ public class ClubQueryServiceImpl implements ClubQueryService {
     public ClubIntroductionDraftResponse findClubIntroductionDraft(Long clubId) {
         Club club = getClub(clubId);
         IntroductionDraft introduction = getIntroduction(clubId);
+        List<String> tags = getTagsForClub(clubId);
 
         return ClubIntroductionDraftResponse.of(club, introduction,
-                s3Service.getDownloadUrl(club.getImageFile().getId()));
+                s3Service.getDownloadUrl(club.getImageFile().getId()), tags);
     }
 
     @Override
@@ -207,45 +216,46 @@ public class ClubQueryServiceImpl implements ClubQueryService {
     public ClubRecruitmentDraftResponse findClubRecruitmentDraft(Long clubId) {
         Club club = getClub(clubId);
         RecruitmentDraft recruitment = getRecruitment(clubId);
+        List<String> tags = getTagsForClub(clubId);
 
         return ClubRecruitmentDraftResponse.of(club, recruitment,
-                s3Service.getDownloadUrl(club.getImageFile().getId()));
+                s3Service.getDownloadUrl(club.getImageFile().getId()), tags);
     }
 
     @Override
-    public ClubSearchResponse findCentralClubsByCondition(String keyword, RecruitmentStatus status, SortBy sortBy,
+    public ClubSearchResponse findCentralClubsByCondition(String keyword, Long tagId, SortBy sortBy,
                                                           CentralClubCategory centralClubCategory, int page,
                                                           int size) {
         Page<ClubSearchProjection> projections = clubSearchRepository.findCentralClubsAsProjection(
-                keyword, status, sortBy, centralClubCategory, false, page, size);
+                keyword, tagId, sortBy, centralClubCategory, false, page, size);
 
         return getClubSearchResponseFromProjection(projections);
     }
 
     @Override
-    public ClubSearchResponse findUnionClubsByCondition(String keyword, RecruitmentStatus status, SortBy sortBy,
+    public ClubSearchResponse findUnionClubsByCondition(String keyword, Long tagId, SortBy sortBy,
                                                         UnionClubCategory unionCategory, int page, int size) {
         Page<ClubSearchProjection> projections = clubSearchRepository.findUnionClubsAsProjection(
-                keyword, status, sortBy, unionCategory, false, page, size);
+                keyword, tagId, sortBy, unionCategory, false, page, size);
 
         return getClubSearchResponseFromProjection(projections);
     }
 
     @Override
-    public ClubSearchResponse findCollegeClubsByCondition(String keyword, RecruitmentStatus status, SortBy sortBy,
+    public ClubSearchResponse findCollegeClubsByCondition(String keyword, Long tagId, SortBy sortBy,
                                                           College college, int page, int size) {
         Page<ClubSearchProjection> projections = clubSearchRepository.findCollegeClubsAsProjection(
-                keyword, status, sortBy, college, false, page, size);
+                keyword, tagId, sortBy, college, false, page, size);
 
         return getClubSearchResponseFromProjection(projections);
     }
 
     @Override
-    public ClubSearchResponse findDepartmentClubsByCondition(String keyword, RecruitmentStatus status, SortBy sortBy,
+    public ClubSearchResponse findDepartmentClubsByCondition(String keyword, Long tagId, SortBy sortBy,
                                                              College college, Department department, int page,
                                                              int size) {
         Page<ClubSearchProjection> projections = clubSearchRepository.findDepartmentClubsAsProjection(
-                keyword, status, sortBy, college, department, false, page, size);
+                keyword, tagId, sortBy, college, department, false, page, size);
 
         return getClubSearchResponseFromProjection(projections);
     }
@@ -262,6 +272,9 @@ public class ClubQueryServiceImpl implements ClubQueryService {
         LocalDateTime renewalDateTime = RENEWAL_DATE.atStartOfDay();
         List<Club> clubs = clubSearchRepository.findRandomClubsUpdatedAfter(renewalDateTime, MAIN_PAGE_OFFSET);
 
+        List<Long> clubIds = clubs.stream().map(Club::getId).toList();
+        Map<Long, List<String>> tagsMap = getTagsForClubs(clubIds);
+
         List<ClubSearchResult> results = clubs.stream()
                 .map(club -> ClubSearchResult.of(
                         club.getId(),
@@ -269,7 +282,7 @@ public class ClubQueryServiceImpl implements ClubQueryService {
                         club.getOneLiner(),
                         resolveImageUrl(club),
                         club.getCategoryInfo().getClubType().getDescription(),
-                        club.getRecruitmentStatus(),
+                        tagsMap.getOrDefault(club.getId(), Collections.emptyList()),
                         CategoryResponse.getTag(club.getCategoryInfo())
                 ))
                 .toList();
@@ -280,26 +293,27 @@ public class ClubQueryServiceImpl implements ClubQueryService {
     @Override
     @Deprecated
     public ClubDetailListResponse findClubsByCondition(
-            String name, CentralClubCategory category, RecruitmentStatus status, SortBy sortBy, int page,
-            int size) {
+            String name, CentralClubCategory category, Long tagId, SortBy sortBy, int page, int size) {
         List<String> profileImageUrls = new ArrayList<>();
-        if (sortBy != null && sortBy.equals(SortBy.RECRUITMENT_STATUS_ASC)) {
-            Page<Club> clubs = clubRepository.findClubsOrderByRecruitmentStatus(name, category, status,
-                    PageRequest.of(page, size));
-            for (Club club : clubs) {
-                profileImageUrls.add(s3Service.getDownloadUrl(club.getImageFile().getId()));
-            }
+        Page<Club> clubs;
 
-            return ClubDetailListResponse.of(clubs, List.of());
+        if (sortBy != null && sortBy.equals(SortBy.RECRUITMENT_STATUS_ASC)) {
+            clubs = clubRepository.findClubsOrderByRecruitmentStatus(name, category, null,
+                    PageRequest.of(page, size));
+        } else {
+            Sort sort = (sortBy != null) ? sortBy.getSort() : SortBy.NAME_ASC.getSort();
+            Pageable pageable = PageRequest.of(page, size, sort);
+            clubs = clubRepository.findAll(ClubSpecifications.findByCondition(name, category, tagId), pageable);
         }
 
-        Sort sort = (sortBy != null) ? sortBy.getSort() : SortBy.NAME_ASC.getSort();
-        Pageable pageable = PageRequest.of(page, size, sort);
-        Page<Club> clubs = clubRepository.findAll(ClubSpecifications.findByCondition(name, category, status), pageable);
         for (Club club : clubs) {
             profileImageUrls.add(s3Service.getDownloadUrl(club.getImageFile().getId()));
         }
-        return ClubDetailListResponse.of(clubs, profileImageUrls);
+
+        List<Long> clubIds = clubs.getContent().stream().map(Club::getId).toList();
+        Map<Long, List<String>> tagsMap = getTagsForClubs(clubIds);
+
+        return ClubDetailListResponse.of(clubs, profileImageUrls, tagsMap);
     }
 
 
@@ -377,9 +391,34 @@ public class ClubQueryServiceImpl implements ClubQueryService {
         return key == null ? null : s3Service.getDownloadUrl(key);
     }
 
+    private List<String> getTagsForClub(Long clubId) {
+        return clubTagRepository.findByClubIdWithTagsOrderedByPriority(clubId)
+                .stream()
+                .limit(2)
+                .map(ct -> ct.getTag().getName())
+                .toList();
+    }
 
+    private Map<Long, List<String>> getTagsForClubs(List<Long> clubIds) {
+        if (clubIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        List<ClubTag> clubTags = clubTagRepository.findByClubIdsWithTagsOrderedByPriority(clubIds);
+        Map<Long, List<String>> tagsMap = new LinkedHashMap<>();
+        for (ClubTag ct : clubTags) {
+            Long cId = ct.getClub().getId();
+            List<String> tags = tagsMap.computeIfAbsent(cId, k -> new ArrayList<>());
+            if (tags.size() < 2) {
+                tags.add(ct.getTag().getName());
+            }
+        }
+        return tagsMap;
+    }
 
     private ClubSearchResponse getClubSearchResponseFromProjection(Page<ClubSearchProjection> projections) {
+        List<Long> clubIds = projections.getContent().stream().map(ClubSearchProjection::clubId).toList();
+        Map<Long, List<String>> tagsMap = getTagsForClubs(clubIds);
+
         Page<ClubSearchResult> dtoPage = projections.map(p ->
                 ClubSearchResult.of(
                         p.clubId(),
@@ -387,7 +426,7 @@ public class ClubQueryServiceImpl implements ClubQueryService {
                         p.oneLiner(),
                         resolveImageUrlByKey(p.fileKey()),
                         p.clubType().getDescription(),
-                        p.recruitmentStatus(),
+                        tagsMap.getOrDefault(p.clubId(), Collections.emptyList()),
                         p.getTag()
                 )
         );
@@ -395,6 +434,9 @@ public class ClubQueryServiceImpl implements ClubQueryService {
     }
 
     private ClubSearchResponse getClubSearchResponseDTO(Page<Club> clubs) {
+        List<Long> clubIds = clubs.getContent().stream().map(Club::getId).toList();
+        Map<Long, List<String>> tagsMap = getTagsForClubs(clubIds);
+
         Page<ClubSearchResult> dtoPage = clubs.map(club ->
                 ClubSearchResult.of(
                         club.getId(),
@@ -402,7 +444,7 @@ public class ClubQueryServiceImpl implements ClubQueryService {
                         club.getOneLiner(),
                         resolveImageUrl(club),
                         club.getCategoryInfo().getClubType().getDescription(),
-                        club.getRecruitmentStatus(),
+                        tagsMap.getOrDefault(club.getId(), Collections.emptyList()),
                         CategoryResponse.getTag(club.getCategoryInfo())
                 )
         );
@@ -411,6 +453,12 @@ public class ClubQueryServiceImpl implements ClubQueryService {
     }
 
     private ClubSearchResponse getClubSearchResponseDTOForUpdate(Page<ClubRegistration> clubRegistrations) {
+        List<Long> clubIds = clubRegistrations.getContent().stream()
+                .map(ClubRegistration::getClubId)
+                .filter(id -> id != null)
+                .toList();
+        Map<Long, List<String>> tagsMap = getTagsForClubs(clubIds);
+
         Page<ClubSearchResult> dtoPage = clubRegistrations.map(clubRegistration ->
             ClubSearchResult.of(
                 clubRegistration.getId(),
@@ -418,7 +466,7 @@ public class ClubQueryServiceImpl implements ClubQueryService {
                 clubRegistration.getOneLiner(),
                 resolveImageUrl(clubRegistration),
                 clubRegistration.getCategoryInfo().getClubType().getDescription(),
-                null,
+                tagsMap.getOrDefault(clubRegistration.getClubId(), Collections.emptyList()),
                 CategoryResponse.getTag(clubRegistration.getCategoryInfo())
             )
         );

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/ClubSearchRepository.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/ClubSearchRepository.java
@@ -11,35 +11,35 @@ import java.util.List;
 public interface ClubSearchRepository {
 
     Page<Club> findCentralClubsByCondition(
-            String keyword, RecruitmentStatus status, SortBy sortBy,
+            String keyword, Long tagId, SortBy sortBy,
             CentralClubCategory category, boolean onlyWithSns, int page, int size);
 
     Page<ClubSearchProjection> findCentralClubsAsProjection(
-            String keyword, RecruitmentStatus status, SortBy sortBy,
+            String keyword, Long tagId, SortBy sortBy,
             CentralClubCategory category, boolean onlyWithSns, int page, int size);
 
     Page<Club> findUnionClubsByCondition(
-            String keyword, RecruitmentStatus status, SortBy sortBy,
+            String keyword, Long tagId, SortBy sortBy,
             UnionClubCategory category, boolean onlyWithSns, int page, int size);
 
     Page<ClubSearchProjection> findUnionClubsAsProjection(
-            String keyword, RecruitmentStatus status, SortBy sortBy,
+            String keyword, Long tagId, SortBy sortBy,
             UnionClubCategory category, boolean onlyWithSns, int page, int size);
 
     Page<Club> findCollegeClubsByCondition(
-            String keyword, RecruitmentStatus status, SortBy sortBy,
+            String keyword, Long tagId, SortBy sortBy,
             College college, boolean onlyWithSns, int page, int size);
 
     Page<ClubSearchProjection> findCollegeClubsAsProjection(
-            String keyword, RecruitmentStatus status, SortBy sortBy,
+            String keyword, Long tagId, SortBy sortBy,
             College college, boolean onlyWithSns, int page, int size);
 
     Page<Club> findDepartmentClubsByCondition(
-            String keyword, RecruitmentStatus status, SortBy sortBy,
+            String keyword, Long tagId, SortBy sortBy,
             College college, Department departmentName, boolean onlyWithSns, int page, int size);
 
     Page<ClubSearchProjection> findDepartmentClubsAsProjection(
-            String keyword, RecruitmentStatus status, SortBy sortBy,
+            String keyword, Long tagId, SortBy sortBy,
             College college, Department departmentName, boolean onlyWithSns, int page, int size);
 
     Page<Club> findPopularClubs(int page, int size);

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/ClubSpecifications.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/ClubSpecifications.java
@@ -1,17 +1,18 @@
 package kr.hanjari.backend.domain.club.domain.repository.search;
 
 import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Subquery;
 import java.util.ArrayList;
 import java.util.List;
 import kr.hanjari.backend.domain.club.domain.entity.Club;
 import kr.hanjari.backend.domain.club.domain.enums.CentralClubCategory;
-import kr.hanjari.backend.domain.club.domain.enums.RecruitmentStatus;
+import kr.hanjari.backend.domain.tag.domain.entity.ClubTag;
 import org.springframework.data.jpa.domain.Specification;
 
 public class ClubSpecifications {
 
     public static Specification<Club> findByCondition(
-            String name, CentralClubCategory centralClubCategory, RecruitmentStatus recruitmentStatus) {
+            String name, CentralClubCategory centralClubCategory, Long tagId) {
 
         return (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
@@ -21,10 +22,16 @@ public class ClubSpecifications {
             if (centralClubCategory != null) {
                 predicates.add(cb.equal(root.get("category"), centralClubCategory));
             }
-            if (recruitmentStatus != null) {
-                predicates.add(cb.equal(root.get("recruitmentStatus"), recruitmentStatus));
+            if (tagId != null) {
+                Subquery<Long> subquery = query.subquery(Long.class);
+                var ctRoot = subquery.from(ClubTag.class);
+                subquery.select(cb.literal(1L))
+                        .where(
+                                cb.equal(ctRoot.get("club").get("id"), root.get("id")),
+                                cb.equal(ctRoot.get("tag").get("id"), tagId)
+                        );
+                predicates.add(cb.exists(subquery));
             }
-
             return cb.and(predicates.toArray(new Predicate[0]));
         };
     }

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/impl/ClubSearchRepositoryImpl.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/impl/ClubSearchRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,10 +18,10 @@ import kr.hanjari.backend.domain.club.domain.enums.CentralClubCategory;
 import kr.hanjari.backend.domain.club.domain.enums.ClubType;
 import kr.hanjari.backend.domain.club.domain.enums.College;
 import kr.hanjari.backend.domain.club.domain.enums.Department;
-import kr.hanjari.backend.domain.club.domain.enums.RecruitmentStatus;
 import kr.hanjari.backend.domain.club.domain.enums.SortBy;
 import kr.hanjari.backend.domain.club.domain.enums.UnionClubCategory;
 import kr.hanjari.backend.domain.club.domain.repository.search.ClubSearchRepository;
+import kr.hanjari.backend.domain.tag.domain.entity.QClubTag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -33,7 +34,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
     private final JPAQueryFactory query;
 
     @Override
-    public Page<Club> findCentralClubsByCondition(String keyword, RecruitmentStatus status, SortBy sortBy,
+    public Page<Club> findCentralClubsByCondition(String keyword, Long tagId, SortBy sortBy,
                                                   CentralClubCategory category, boolean onlyWithSns, int page, int size) {
         QClub club = QClub.club;
         List<Club> clubs = query.select(club)
@@ -41,7 +42,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                 .where(
                         club.categoryInfo.clubType.eq(ClubType.CENTRAL),
                         nameContains(keyword),
-                        statusEq(status),
+                        tagFilter(tagId),
                         centralCategoryEq(category),
                         snsFieldCheck(onlyWithSns))
                 .orderBy(getOrderSpecifier(sortBy))
@@ -54,7 +55,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                 .where(
                         club.categoryInfo.clubType.eq(ClubType.CENTRAL),
                         nameContains(keyword),
-                        statusEq(status),
+                        tagFilter(tagId),
                         centralCategoryEq(category),
                         snsFieldCheck(onlyWithSns))
                 .fetchOne();
@@ -64,7 +65,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
 
     @Override
     public Page<ClubSearchProjection> findCentralClubsAsProjection(
-            String keyword, RecruitmentStatus status, SortBy sortBy,
+            String keyword, Long tagId, SortBy sortBy,
             CentralClubCategory category, boolean onlyWithSns, int page, int size) {
         QClub club = QClub.club;
         QFile file = QFile.file;
@@ -80,7 +81,6 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                         club.categoryInfo.unionCategory,
                         club.categoryInfo.college,
                         club.categoryInfo.department,
-                        club.recruitmentStatus,
                         club.snsUrl
                 ))
                 .from(club)
@@ -88,7 +88,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                 .where(
                         club.categoryInfo.clubType.eq(ClubType.CENTRAL),
                         nameContains(keyword),
-                        statusEq(status),
+                        tagFilter(tagId),
                         centralCategoryEq(category),
                         snsFieldCheck(onlyWithSns))
                 .orderBy(getOrderSpecifier(sortBy))
@@ -101,7 +101,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                 .where(
                         club.categoryInfo.clubType.eq(ClubType.CENTRAL),
                         nameContains(keyword),
-                        statusEq(status),
+                        tagFilter(tagId),
                         centralCategoryEq(category),
                         snsFieldCheck(onlyWithSns))
                 .fetchOne();
@@ -111,7 +111,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
 
     @Override
     public Page<ClubSearchProjection> findUnionClubsAsProjection(
-            String keyword, RecruitmentStatus status, SortBy sortBy,
+            String keyword, Long tagId, SortBy sortBy,
             UnionClubCategory category, boolean onlyWithSns, int page, int size) {
         QClub club = QClub.club;
         QFile file = QFile.file;
@@ -127,7 +127,6 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                         club.categoryInfo.unionCategory,
                         club.categoryInfo.college,
                         club.categoryInfo.department,
-                        club.recruitmentStatus,
                         club.snsUrl
                 ))
                 .from(club)
@@ -135,7 +134,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                 .where(
                         club.categoryInfo.clubType.eq(ClubType.UNION),
                         nameContains(keyword),
-                        statusEq(status),
+                        tagFilter(tagId),
                         unionCategoryEq(category),
                         snsFieldCheck(onlyWithSns))
                 .orderBy(getOrderSpecifier(sortBy))
@@ -148,7 +147,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                 .where(
                         club.categoryInfo.clubType.eq(ClubType.UNION),
                         nameContains(keyword),
-                        statusEq(status),
+                        tagFilter(tagId),
                         unionCategoryEq(category),
                         snsFieldCheck(onlyWithSns))
                 .fetchOne();
@@ -157,7 +156,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
     }
 
     @Override
-    public Page<Club> findUnionClubsByCondition(String keyword, RecruitmentStatus status, SortBy sortBy,
+    public Page<Club> findUnionClubsByCondition(String keyword, Long tagId, SortBy sortBy,
                                                 UnionClubCategory category, boolean onlyWithSns, int page, int size) {
         QClub club = QClub.club;
 
@@ -166,7 +165,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                 .where(
                         club.categoryInfo.clubType.eq(ClubType.UNION),
                         nameContains(keyword),
-                        statusEq(status),
+                        tagFilter(tagId),
                         unionCategoryEq(category),
                         snsFieldCheck(onlyWithSns))
                 .orderBy(getOrderSpecifier(sortBy))
@@ -179,7 +178,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                 .where(
                         club.categoryInfo.clubType.eq(ClubType.UNION),
                         nameContains(keyword),
-                        statusEq(status),
+                        tagFilter(tagId),
                         unionCategoryEq(category),
                         snsFieldCheck(onlyWithSns))
                 .fetchOne();
@@ -189,7 +188,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
 
     @Override
     public Page<ClubSearchProjection> findCollegeClubsAsProjection(
-            String keyword, RecruitmentStatus status, SortBy sortBy,
+            String keyword, Long tagId, SortBy sortBy,
             College college, boolean onlyWithSns, int page, int size) {
         QClub club = QClub.club;
         QFile file = QFile.file;
@@ -205,7 +204,6 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                         club.categoryInfo.unionCategory,
                         club.categoryInfo.college,
                         club.categoryInfo.department,
-                        club.recruitmentStatus,
                         club.snsUrl
                 ))
                 .from(club)
@@ -213,7 +211,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                 .where(
                         club.categoryInfo.clubType.eq(ClubType.COLLEGE),
                         nameContains(keyword),
-                        statusEq(status),
+                        tagFilter(tagId),
                         collegeEq(college),
                         snsFieldCheck(onlyWithSns))
                 .orderBy(getOrderSpecifier(sortBy))
@@ -226,7 +224,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                 .where(
                         club.categoryInfo.clubType.eq(ClubType.COLLEGE),
                         nameContains(keyword),
-                        statusEq(status),
+                        tagFilter(tagId),
                         collegeEq(college),
                         snsFieldCheck(onlyWithSns))
                 .fetchOne();
@@ -235,7 +233,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
     }
 
     @Override
-    public Page<Club> findCollegeClubsByCondition(String keyword, RecruitmentStatus status, SortBy sortBy,
+    public Page<Club> findCollegeClubsByCondition(String keyword, Long tagId, SortBy sortBy,
                                                   College college, boolean onlyWithSns, int page, int size) {
         QClub club = QClub.club;
 
@@ -244,7 +242,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                 .where(
                         club.categoryInfo.clubType.eq(ClubType.COLLEGE),
                         nameContains(keyword),
-                        statusEq(status),
+                        tagFilter(tagId),
                         collegeEq(college),
                         snsFieldCheck(onlyWithSns))
                 .orderBy(getOrderSpecifier(sortBy))
@@ -257,7 +255,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                 .where(
                         club.categoryInfo.clubType.eq(ClubType.COLLEGE),
                         nameContains(keyword),
-                        statusEq(status),
+                        tagFilter(tagId),
                         collegeEq(college),
                         snsFieldCheck(onlyWithSns))
                 .fetchOne();
@@ -267,7 +265,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
 
     @Override
     public Page<ClubSearchProjection> findDepartmentClubsAsProjection(
-            String keyword, RecruitmentStatus status, SortBy sortBy,
+            String keyword, Long tagId, SortBy sortBy,
             College college, Department departmentName, boolean onlyWithSns, int page, int size) {
         QClub club = QClub.club;
         QFile file = QFile.file;
@@ -283,7 +281,6 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                         club.categoryInfo.unionCategory,
                         club.categoryInfo.college,
                         club.categoryInfo.department,
-                        club.recruitmentStatus,
                         club.snsUrl
                 ))
                 .from(club)
@@ -291,7 +288,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                 .where(
                         club.categoryInfo.clubType.eq(ClubType.DEPARTMENT),
                         nameContains(keyword),
-                        statusEq(status),
+                        tagFilter(tagId),
                         collegeEq(college),
                         departmentEq(departmentName),
                         snsFieldCheck(onlyWithSns))
@@ -305,7 +302,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                 .where(
                         club.categoryInfo.clubType.eq(ClubType.DEPARTMENT),
                         nameContains(keyword),
-                        statusEq(status),
+                        tagFilter(tagId),
                         collegeEq(college),
                         departmentEq(departmentName),
                         snsFieldCheck(onlyWithSns))
@@ -315,7 +312,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
     }
 
     @Override
-    public Page<Club> findDepartmentClubsByCondition(String keyword, RecruitmentStatus status, SortBy sortBy,
+    public Page<Club> findDepartmentClubsByCondition(String keyword, Long tagId, SortBy sortBy,
                                                      College college, Department departmentName, boolean onlyWithSns, int page, int size) {
         QClub club = QClub.club;
 
@@ -324,7 +321,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                 .where(
                         club.categoryInfo.clubType.eq(ClubType.DEPARTMENT),
                         nameContains(keyword),
-                        statusEq(status),
+                        tagFilter(tagId),
                         collegeEq(college),
                         departmentEq(departmentName),
                         snsFieldCheck(onlyWithSns))
@@ -338,7 +335,7 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
                 .where(
                         club.categoryInfo.clubType.eq(ClubType.DEPARTMENT),
                         nameContains(keyword),
-                        statusEq(status),
+                        tagFilter(tagId),
                         collegeEq(college),
                         departmentEq(departmentName))
                 .fetchOne();
@@ -455,8 +452,14 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
         return type != null ? QClub.club.categoryInfo.clubType.eq(type) : null;
     }
 
-    private BooleanExpression statusEq(RecruitmentStatus status) {
-        return status != null ? QClub.club.recruitmentStatus.eq(status) : null;
+    private BooleanExpression tagFilter(Long tagId) {
+        if (tagId == null) return null;
+        QClubTag clubTag = QClubTag.clubTag;
+        return QClub.club.id.in(
+                JPAExpressions.select(clubTag.club.id)
+                        .from(clubTag)
+                        .where(clubTag.tag.id.eq(tagId))
+        );
     }
 
     private BooleanExpression centralCategoryEq(CentralClubCategory category) {
@@ -478,7 +481,6 @@ public class ClubSearchRepositoryImpl implements ClubSearchRepository {
     private BooleanExpression snsFieldCheck(boolean flag) {
         return flag ?
                 QClub.club.snsUrl.isNotEmpty() :
-//                QClub.club.snsUrl.isNotNull().and(QClub.club.snsUrl.ne("")) :
                 null;
     }
 

--- a/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/projection/ClubSearchProjection.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/domain/repository/search/projection/ClubSearchProjection.java
@@ -4,7 +4,6 @@ import kr.hanjari.backend.domain.club.domain.enums.CentralClubCategory;
 import kr.hanjari.backend.domain.club.domain.enums.ClubType;
 import kr.hanjari.backend.domain.club.domain.enums.College;
 import kr.hanjari.backend.domain.club.domain.enums.Department;
-import kr.hanjari.backend.domain.club.domain.enums.RecruitmentStatus;
 import kr.hanjari.backend.domain.club.domain.enums.UnionClubCategory;
 
 public record ClubSearchProjection(
@@ -17,7 +16,6 @@ public record ClubSearchProjection(
         UnionClubCategory unionCategory,
         College college,
         Department department,
-        RecruitmentStatus recruitmentStatus,
         String snsUrl
 ) {
     public String getTag() {

--- a/src/main/java/kr/hanjari/backend/domain/club/presentation/controller/ClubSearchController.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/presentation/controller/ClubSearchController.java
@@ -7,7 +7,6 @@ import kr.hanjari.backend.domain.club.application.query.ClubQueryService;
 import kr.hanjari.backend.domain.club.domain.enums.CentralClubCategory;
 import kr.hanjari.backend.domain.club.domain.enums.College;
 import kr.hanjari.backend.domain.club.domain.enums.Department;
-import kr.hanjari.backend.domain.club.domain.enums.RecruitmentStatus;
 import kr.hanjari.backend.domain.club.domain.enums.SortBy;
 import kr.hanjari.backend.domain.club.domain.enums.UnionClubCategory;
 import kr.hanjari.backend.domain.club.presentation.dto.response.ClubDetailListResponse;
@@ -30,12 +29,12 @@ public class ClubSearchController {
     @Deprecated
     @Tag(name = "Club Search v1", description = "Club Search v1 API")
     @Operation(summary = "[동아리 검색] 동아리 검색", description = """
-            ## 입력한 조건에 맞는 동아리를 검색합니다. 
-            - **keyword**: 동아리 이름에서 서 검색할 키워드 \n
+            ## 입력한 조건에 맞는 동아리를 검색합니다.
+            - **keyword**: 동아리 이름에서 검색할 키워드 \n
             - **category**: 동아리 카테고리 \n
-            - **status**: 동아리 모집 상태 \n
+            - **tagId**: 태그 ID \n
             - **sortBy**: 정렬 기준 \n
-            
+
             ### 모든 조건은 선택적으로 입력할 수 있습니다. (필수 X)
             아무 값도 입력 하지 않을 경우, 가나다순으로 정렬하여 전체 동아리를 조회합니다. page의 기본 값은 0, size의 기본 값은 10입니다.
             """)
@@ -43,13 +42,13 @@ public class ClubSearchController {
     public ApiResponse<ClubDetailListResponse> getClubsByCondition(
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) CentralClubCategory category,
-            @RequestParam(required = false) RecruitmentStatus status,
+            @RequestParam(required = false) Long tagId,
             @RequestParam(required = false) SortBy sortBy,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
         return ApiResponse.onSuccess(
-                clubQueryService.findClubsByCondition(keyword, category, status, sortBy, page, size));
+                clubQueryService.findClubsByCondition(keyword, category, tagId, sortBy, page, size));
     }
 
     @GetMapping("/central")
@@ -57,23 +56,23 @@ public class ClubSearchController {
     @Operation(summary = "[동아리 검색] 중앙 동아리 검색", description = """
             ## 중앙 동아리를 검색합니다.
             - **keyword**: 동아리 이름에서 검색할 키워드 \n
-            - **status**: 동아리 모집 상태 \n
+            - **tagId**: 태그 ID \n
             - **sortBy**: 정렬 기준 \n
             - **category**: 중앙 동아리 카테고리 \n
-            
+
             ### 모든 조건은 선택적으로 입력할 수 있습니다. (필수 X)
             아무 값도 입력 하지 않을 경우, 가나다순으로 정렬하여 전체 중앙 동아리를 조회합니다. page의 기본 값은 0, size의 기본 값은 10입니다.
             """)
     public ApiResponse<ClubSearchResponse> getCentralClubsByCondition(
             @RequestParam(required = false) String keyword,
-            @RequestParam(required = false) RecruitmentStatus status,
+            @RequestParam(required = false) Long tagId,
             @RequestParam(required = false) SortBy sortBy,
             @RequestParam(required = false) CentralClubCategory category,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
         return ApiResponse.onSuccess(
-                clubQueryService.findCentralClubsByCondition(keyword, status, sortBy, category, page, size));
+                clubQueryService.findCentralClubsByCondition(keyword, tagId, sortBy, category, page, size));
     }
 
 
@@ -82,67 +81,67 @@ public class ClubSearchController {
     @Operation(summary = "[동아리 검색] 연합 동아리 검색", description = """
             ## 연합 동아리를 검색합니다.
             - **keyword**: 동아리 이름에서 검색할 키워드 \n
-            - **status**: 동아리 모집 상태 \n
+            - **tagId**: 태그 ID \n
             - **sortBy**: 정렬 기준 \n
             - **category**: 연합 동아리 카테고리 \n
-            
+
             ### 모든 조건은 선택적으로 입력할 수 있습니다. (필수 X)
             아무 값도 입력 하지 않을 경우, 가나다순으로 정렬하여 전체 연합 동아리를 조회합니다. page의 기본 값은 0, size의 기본 값은 10입니다.
             """)
     public ApiResponse<ClubSearchResponse> getUnionClubsByCondition(
             @RequestParam(required = false) String keyword,
-            @RequestParam(required = false) RecruitmentStatus status,
+            @RequestParam(required = false) Long tagId,
             @RequestParam(required = false) SortBy sortBy,
             @RequestParam(required = false) UnionClubCategory category,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
         return ApiResponse.onSuccess(
-                clubQueryService.findUnionClubsByCondition(keyword, status, sortBy, category, page, size));
+                clubQueryService.findUnionClubsByCondition(keyword, tagId, sortBy, category, page, size));
     }
 
 
     @GetMapping("/college")
     @Tag(name = "Club Search v2", description = "Club Search v2 API")
     @Operation(summary = "[동아리 검색] 단과대 동아리 검색", description = """
-            ## 중앙 동아리를 검색합니다.
+            ## 단과대 동아리를 검색합니다.
             - **keyword**: 동아리 이름에서 검색할 키워드 \n
-            - **status**: 동아리 모집 상태 \n
+            - **tagId**: 태그 ID \n
             - **sortBy**: 정렬 기준 \n
             - **college**: 단과대 카테고리 \n
-            
+
             ### 모든 조건은 선택적으로 입력할 수 있습니다. (필수 X)
             아무 값도 입력 하지 않을 경우, 가나다순으로 정렬하여 전체 단과대 동아리를 조회합니다. page의 기본 값은 0, size의 기본 값은 10입니다.
             """)
     public ApiResponse<ClubSearchResponse> getCollageClubsByCondition(
             @RequestParam(required = false) String keyword,
-            @RequestParam(required = false) RecruitmentStatus status,
+            @RequestParam(required = false) Long tagId,
             @RequestParam(required = false) SortBy sortBy,
             @RequestParam(required = false) College college,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
         return ApiResponse.onSuccess(
-                clubQueryService.findCollegeClubsByCondition(keyword, status, sortBy, college, page, size));
+                clubQueryService.findCollegeClubsByCondition(keyword, tagId, sortBy, college, page, size));
     }
 
 
     @GetMapping("/department")
     @Tag(name = "Club Search v2", description = "Club Search v2 API")
     @Operation(summary = "[동아리 검색] 학과 동아리 검색", description = """
-            ## 중앙 동아리를 검색합니다.
+            ## 학과 동아리를 검색합니다.
             - **keyword**: 동아리 이름에서 검색할 키워드 \n
-            - **status**: 동아리 모집 상태 \n
+            - **tagId**: 태그 ID \n
             - **sortBy**: 정렬 기준 \n
             - **college**: 단과대 카테고리 \n
             - **department**: 학과 카테고리 \n
-            
+
             ### 모든 조건은 선택적으로 입력할 수 있습니다. (필수 X)
-            아무 값도 입력 하지 않을 경우, 가나다순으로 정렬하여 전체 중앙 동아리를 조회합니다. page의 기본 값은 0, size의 기본 값은 10입니다.
+            아무 값도 입력 하지 않을 경우, 가나다순으로 정렬하여 전체 학과 동아리를 조회합니다. page의 기본 값은 0, size의 기본 값은 10입니다.
             """)
-    public ApiResponse<ClubSearchResponse> getCentralClubsByCondition(
+    public ApiResponse<ClubSearchResponse> getDepartmentClubsByCondition(
             @RequestParam(required = false) String keyword,
-            @RequestParam(required = false) RecruitmentStatus status,
+            @RequestParam(required = false) Long tagId,
             @RequestParam(required = false) SortBy sortBy,
             @RequestParam(required = false) College college,
             @RequestParam(required = false) Department department,
@@ -150,7 +149,7 @@ public class ClubSearchController {
             @RequestParam(defaultValue = "10") int size
     ) {
         return ApiResponse.onSuccess(
-                clubQueryService.findDepartmentClubsByCondition(keyword, status, sortBy, college, department, page,
+                clubQueryService.findDepartmentClubsByCondition(keyword, tagId, sortBy, college, department, page,
                         size));
     }
 
@@ -183,8 +182,8 @@ public class ClubSearchController {
             ## 동아리 수정 요청을 조회합니다.
             """)
     public ApiResponse<ClubSearchResponse> getClubUpdateList(
-        @RequestParam (defaultValue = "0") int page,
-        @RequestParam (defaultValue = "10") int size
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size
     ) {
         return ApiResponse.onSuccess(
             clubQueryService.findUpdateRequests(page, size));

--- a/src/main/java/kr/hanjari/backend/domain/club/presentation/dto/response/ClubAdminDetailResponse.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/presentation/dto/response/ClubAdminDetailResponse.java
@@ -1,8 +1,8 @@
 package kr.hanjari.backend.domain.club.presentation.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import kr.hanjari.backend.domain.club.domain.entity.Club;
-import kr.hanjari.backend.domain.club.domain.enums.RecruitmentStatus;
 
 @Schema(description = "DTO for service admin club detail response")
 public record ClubAdminDetailResponse(
@@ -12,8 +12,8 @@ public record ClubAdminDetailResponse(
         String name,
         @Schema(description = "Club description (one-liner)", nullable = false, example = "The best central club at Hanyang University ERICA")
         String oneLiner,
-        @Schema(description = "Recruitment status", nullable = false, example = "RECRUITING")
-        RecruitmentStatus recruitmentStatus,
+        @Schema(description = "Club tags (max 2, ordered by priority)", nullable = false)
+        List<String> tags,
         @Schema(description = "Club profile image URL", nullable = true, example = "https://.../profile.png")
         String profileImageUrl,
         @Schema(description = "Application URL", nullable = true, example = "https://forms.gle/...")
@@ -27,12 +27,12 @@ public record ClubAdminDetailResponse(
         @Schema(description = "Club description", nullable = true, example = "We are a club that...")
         String description
 ) {
-    public static ClubAdminDetailResponse of(Club club, String profileImageUrl) {
+    public static ClubAdminDetailResponse of(Club club, String profileImageUrl, List<String> tags) {
         return new ClubAdminDetailResponse(
                 club.getId(),
                 club.getName(),
                 club.getOneLiner(),
-                club.getRecruitmentStatus(),
+                tags,
                 profileImageUrl,
                 club.getApplicationUrl(),
                 CategoryResponse.from(club.getCategoryInfo()),

--- a/src/main/java/kr/hanjari/backend/domain/club/presentation/dto/response/ClubDetailListResponse.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/presentation/dto/response/ClubDetailListResponse.java
@@ -1,7 +1,9 @@
 package kr.hanjari.backend.domain.club.presentation.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.IntStream;
 import kr.hanjari.backend.domain.club.domain.entity.Club;
 import org.springframework.data.domain.Page;
@@ -13,9 +15,14 @@ public record ClubDetailListResponse(
         @Schema(description = "Total number of elements", nullable = false, example = "100")
         Integer totalElements
 ) {
-    public static ClubDetailListResponse of(Page<Club> clubs, List<String> profileImageUrls) {
+    public static ClubDetailListResponse of(Page<Club> clubs, List<String> profileImageUrls,
+                                            Map<Long, List<String>> tagsMap) {
         List<ClubResponse> clubResponseList = IntStream.range(0, clubs.getContent().size())
-                .mapToObj(i -> ClubResponse.of(clubs.getContent().get(i), profileImageUrls.get(i)))
+                .mapToObj(i -> {
+                    Club club = clubs.getContent().get(i);
+                    return ClubResponse.of(club, profileImageUrls.get(i),
+                            tagsMap.getOrDefault(club.getId(), Collections.emptyList()));
+                })
                 .toList();
 
         return new ClubDetailListResponse(clubResponseList, (int) clubs.getTotalElements());

--- a/src/main/java/kr/hanjari/backend/domain/club/presentation/dto/response/ClubOverviewResponse.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/presentation/dto/response/ClubOverviewResponse.java
@@ -1,8 +1,8 @@
 package kr.hanjari.backend.domain.club.presentation.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import kr.hanjari.backend.domain.club.domain.entity.Club;
-import kr.hanjari.backend.domain.club.domain.enums.RecruitmentStatus;
 
 @Schema(description = "DTO for club overview response")
 public record ClubOverviewResponse(
@@ -12,8 +12,8 @@ public record ClubOverviewResponse(
         String name,
         @Schema(description = "Club description (one-liner)", nullable = false, example = "The best central club at Hanyang University ERICA")
         String oneLiner,
-        @Schema(description = "Recruitment status", nullable = false, example = "RECRUITING")
-        RecruitmentStatus recruitmentStatus,
+        @Schema(description = "Club tags (max 2, ordered by priority)", nullable = false)
+        List<String> tags,
         @Schema(description = "Club profile image URL", nullable = true, example = "https://.../profile.png")
         String profileImageUrl,
         @Schema(description = "Application URL", nullable = true, example = "https://forms.gle/...")
@@ -23,12 +23,12 @@ public record ClubOverviewResponse(
         @Schema(description = "Club category tag", nullable = false, example = "Academic")
         String tag
 ) {
-    public static ClubOverviewResponse of(Club club, String profileImageUrl) {
+    public static ClubOverviewResponse of(Club club, String profileImageUrl, List<String> tags) {
         return new ClubOverviewResponse(
                 club.getId(),
                 club.getName(),
                 club.getOneLiner(),
-                club.getRecruitmentStatus(),
+                tags,
                 profileImageUrl,
                 club.getApplicationUrl(),
                 CategoryResponse.from(club.getCategoryInfo()),

--- a/src/main/java/kr/hanjari/backend/domain/club/presentation/dto/response/ClubResponse.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/presentation/dto/response/ClubResponse.java
@@ -1,9 +1,9 @@
 package kr.hanjari.backend.domain.club.presentation.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import kr.hanjari.backend.domain.club.domain.entity.Club;
 import kr.hanjari.backend.domain.club.domain.enums.ClubType;
-import kr.hanjari.backend.domain.club.domain.enums.RecruitmentStatus;
 
 @Schema(description = "DTO for club response")
 public record ClubResponse(
@@ -13,8 +13,8 @@ public record ClubResponse(
         String name,
         @Schema(description = "Club description (one-liner)", nullable = false, example = "The best central club at Hanyang University ERICA")
         String description,
-        @Schema(description = "Recruitment status", nullable = false, example = "RECRUITING")
-        RecruitmentStatus recruitmentStatus,
+        @Schema(description = "Club tags (max 2, ordered by priority)", nullable = false)
+        List<String> tags,
         @Schema(description = "Club profile image URL", nullable = true, example = "https://.../profile.png")
         String profileImageUrl,
         @Schema(description = "Club activities", nullable = true, example = "Regular meeting every Monday")
@@ -26,7 +26,7 @@ public record ClubResponse(
         @Schema(description = "Leader's phone number", nullable = true, example = "010-1234-5678")
         String leaderPhone,
         @Schema(description = "Membership fee", nullable = true, example = "10000")
-        String  membershipFee,
+        String membershipFee,
         @Schema(description = "SNS URL", nullable = true, example = "https://www.instagram.com/hanjari_")
         String snsUrl,
         @Schema(description = "Application URL", nullable = true, example = "https://forms.gle/...")
@@ -35,12 +35,12 @@ public record ClubResponse(
         ClubType clubType,
         String tag
 ) {
-    public static ClubResponse of(Club club, String profileImageUrl) {
+    public static ClubResponse of(Club club, String profileImageUrl, List<String> tags) {
         return new ClubResponse(
                 club.getId(),
                 club.getName(),
                 club.getOneLiner(),
-                club.getRecruitmentStatus(),
+                tags,
                 profileImageUrl,
                 club.getScheduleDescription(),
                 club.getLeaderName(),

--- a/src/main/java/kr/hanjari/backend/domain/club/presentation/dto/response/ClubSearchResponse.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/presentation/dto/response/ClubSearchResponse.java
@@ -2,7 +2,7 @@ package kr.hanjari.backend.domain.club.presentation.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
-import kr.hanjari.backend.domain.club.domain.enums.RecruitmentStatus;
+import org.springframework.data.domain.Page;
 
 @Schema(description = "DTO for club search response")
 public record ClubSearchResponse(
@@ -22,7 +22,7 @@ public record ClubSearchResponse(
         return new ClubSearchResponse(content, totalElements, page, size, totalPages);
     }
 
-    public static ClubSearchResponse of(org.springframework.data.domain.Page<ClubSearchResult> page) {
+    public static ClubSearchResponse of(Page<ClubSearchResult> page) {
         return new ClubSearchResponse(
                 page.getContent(),
                 page.getTotalElements(),
@@ -44,14 +44,14 @@ public record ClubSearchResponse(
             String profileImageUrl,
             @Schema(description = "Category name", nullable = false, example = "Academic")
             String categoryName,
-            @Schema(description = "Recruitment status", nullable = false, example = "RECRUITING")
-            RecruitmentStatus recruitmentStatus,
+            @Schema(description = "Club tags (max 2, ordered by priority)", nullable = false)
+            List<String> tags,
             @Schema(description = "Category tag", nullable = false, example = "Academic")
             String tag
     ) {
         public static ClubSearchResult of(Long id, String name, String oneLiner, String profileImageUrl,
-                                          String categoryName, RecruitmentStatus recruitmentStatus, String tag) {
-            return new ClubSearchResult(id, name, oneLiner, profileImageUrl, categoryName, recruitmentStatus, tag);
+                                          String categoryName, List<String> tags, String tag) {
+            return new ClubSearchResult(id, name, oneLiner, profileImageUrl, categoryName, tags, tag);
         }
     }
 }

--- a/src/main/java/kr/hanjari/backend/domain/club/presentation/dto/response/draft/ClubIntroductionDraftResponse.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/presentation/dto/response/draft/ClubIntroductionDraftResponse.java
@@ -1,6 +1,7 @@
 package kr.hanjari.backend.domain.club.presentation.dto.response.draft;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import kr.hanjari.backend.domain.club.domain.entity.Club;
 import kr.hanjari.backend.domain.club.domain.entity.draft.IntroductionDraft;
 import kr.hanjari.backend.domain.club.presentation.dto.response.ClubResponse;
@@ -17,9 +18,9 @@ public record ClubIntroductionDraftResponse(
         String recruitment
 ) {
     public static ClubIntroductionDraftResponse of(Club club, IntroductionDraft introductionDraft,
-                                                   String profileImageUrl) {
+                                                   String profileImageUrl, List<String> tags) {
         return new ClubIntroductionDraftResponse(
-                ClubResponse.of(club, profileImageUrl),
+                ClubResponse.of(club, profileImageUrl, tags),
                 introductionDraft.getContent1(),
                 introductionDraft.getContent2(),
                 introductionDraft.getContent3()

--- a/src/main/java/kr/hanjari/backend/domain/club/presentation/dto/response/draft/ClubRecruitmentDraftResponse.java
+++ b/src/main/java/kr/hanjari/backend/domain/club/presentation/dto/response/draft/ClubRecruitmentDraftResponse.java
@@ -1,6 +1,7 @@
 package kr.hanjari.backend.domain.club.presentation.dto.response.draft;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import kr.hanjari.backend.domain.club.domain.entity.Club;
 import kr.hanjari.backend.domain.club.domain.entity.draft.RecruitmentDraft;
 import kr.hanjari.backend.domain.club.presentation.dto.response.ClubResponse;
@@ -18,9 +19,10 @@ public record ClubRecruitmentDraftResponse(
         @Schema(description = "Other recruitment information", nullable = true, example = "For further questions...")
         String etc
 ) {
-    public static ClubRecruitmentDraftResponse of(Club club, RecruitmentDraft recruitment, String profileImageUrl) {
+    public static ClubRecruitmentDraftResponse of(Club club, RecruitmentDraft recruitment, String profileImageUrl,
+                                                  List<String> tags) {
         return new ClubRecruitmentDraftResponse(
-                ClubResponse.of(club, profileImageUrl),
+                ClubResponse.of(club, profileImageUrl, tags),
                 recruitment.getDue(),
                 recruitment.getTarget(),
                 recruitment.getNotice(),

--- a/src/main/java/kr/hanjari/backend/domain/document/presentation/controller/DocumentController.java
+++ b/src/main/java/kr/hanjari/backend/domain/document/presentation/controller/DocumentController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+@Deprecated
 @RestController
 @RequestMapping("/api/documents")
 @RequiredArgsConstructor

--- a/src/main/java/kr/hanjari/backend/domain/tag/application/command/TagCommandService.java
+++ b/src/main/java/kr/hanjari/backend/domain/tag/application/command/TagCommandService.java
@@ -1,0 +1,10 @@
+package kr.hanjari.backend.domain.tag.application.command;
+
+public interface TagCommandService {
+
+    Long createTag(String name, Integer priority);
+
+    void addTagToClub(Long clubId, Long tagId);
+
+    void removeTagFromClub(Long clubId, Long tagId);
+}

--- a/src/main/java/kr/hanjari/backend/domain/tag/application/command/impl/TagCommandServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/domain/tag/application/command/impl/TagCommandServiceImpl.java
@@ -1,0 +1,53 @@
+package kr.hanjari.backend.domain.tag.application.command.impl;
+
+import kr.hanjari.backend.domain.club.domain.entity.Club;
+import kr.hanjari.backend.domain.club.domain.repository.ClubRepository;
+import kr.hanjari.backend.domain.tag.application.command.TagCommandService;
+import kr.hanjari.backend.domain.tag.domain.entity.ClubTag;
+import kr.hanjari.backend.domain.tag.domain.entity.Tag;
+import kr.hanjari.backend.domain.tag.domain.repository.ClubTagRepository;
+import kr.hanjari.backend.domain.tag.domain.repository.TagRepository;
+import kr.hanjari.backend.global.payload.code.status.ErrorStatus;
+import kr.hanjari.backend.global.payload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TagCommandServiceImpl implements TagCommandService {
+
+    private final TagRepository tagRepository;
+    private final ClubTagRepository clubTagRepository;
+    private final ClubRepository clubRepository;
+
+    @Override
+    public Long createTag(String name, Integer priority) {
+        if (tagRepository.existsByName(name)) {
+            throw new GeneralException(ErrorStatus._TAG_ALREADY_EXISTS);
+        }
+        Tag tag = Tag.builder().name(name).priority(priority).build();
+        return tagRepository.save(tag).getId();
+    }
+
+    @Override
+    public void addTagToClub(Long clubId, Long tagId) {
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._CLUB_NOT_FOUND));
+        Tag tag = tagRepository.findById(tagId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._TAG_NOT_FOUND));
+        if (clubTagRepository.existsByClubIdAndTagId(clubId, tagId)) {
+            throw new GeneralException(ErrorStatus._TAG_ALREADY_ASSIGNED);
+        }
+        clubTagRepository.save(ClubTag.create(club, tag));
+    }
+
+    @Override
+    public void removeTagFromClub(Long clubId, Long tagId) {
+        if (!clubTagRepository.existsByClubIdAndTagId(clubId, tagId)) {
+            throw new GeneralException(ErrorStatus._TAG_NOT_ASSIGNED);
+        }
+        clubTagRepository.deleteByClubIdAndTagId(clubId, tagId);
+    }
+}

--- a/src/main/java/kr/hanjari/backend/domain/tag/application/query/TagQueryService.java
+++ b/src/main/java/kr/hanjari/backend/domain/tag/application/query/TagQueryService.java
@@ -1,0 +1,8 @@
+package kr.hanjari.backend.domain.tag.application.query;
+
+import kr.hanjari.backend.domain.tag.presentation.dto.response.GetAllTagsResponse;
+
+public interface TagQueryService {
+
+    GetAllTagsResponse getAllTags();
+}

--- a/src/main/java/kr/hanjari/backend/domain/tag/application/query/impl/TagQueryServiceImpl.java
+++ b/src/main/java/kr/hanjari/backend/domain/tag/application/query/impl/TagQueryServiceImpl.java
@@ -1,0 +1,21 @@
+package kr.hanjari.backend.domain.tag.application.query.impl;
+
+import kr.hanjari.backend.domain.tag.application.query.TagQueryService;
+import kr.hanjari.backend.domain.tag.domain.repository.TagRepository;
+import kr.hanjari.backend.domain.tag.presentation.dto.response.GetAllTagsResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TagQueryServiceImpl implements TagQueryService {
+
+    private final TagRepository tagRepository;
+
+    @Override
+    public GetAllTagsResponse getAllTags() {
+        return GetAllTagsResponse.of(tagRepository.findAllByOrderByPriorityAsc());
+    }
+}

--- a/src/main/java/kr/hanjari/backend/domain/tag/domain/entity/ClubTag.java
+++ b/src/main/java/kr/hanjari/backend/domain/tag/domain/entity/ClubTag.java
@@ -1,0 +1,46 @@
+package kr.hanjari.backend.domain.tag.domain.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import kr.hanjari.backend.domain.club.domain.entity.Club;
+import kr.hanjari.backend.domain.common.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "club_tag",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"club_id", "tag_id"}))
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ClubTag extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id", nullable = false)
+    private Club club;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id", nullable = false)
+    private Tag tag;
+
+    public static ClubTag create(Club club, Tag tag) {
+        return ClubTag.builder()
+                .club(club)
+                .tag(tag)
+                .build();
+    }
+}

--- a/src/main/java/kr/hanjari/backend/domain/tag/domain/entity/Tag.java
+++ b/src/main/java/kr/hanjari/backend/domain/tag/domain/entity/Tag.java
@@ -1,0 +1,32 @@
+package kr.hanjari.backend.domain.tag.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import kr.hanjari.backend.domain.common.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "tag")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Tag extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, unique = true, length = 20)
+    private String name;
+
+    @Column(name = "priority", nullable = false)
+    private Integer priority;
+}

--- a/src/main/java/kr/hanjari/backend/domain/tag/domain/repository/ClubTagRepository.java
+++ b/src/main/java/kr/hanjari/backend/domain/tag/domain/repository/ClubTagRepository.java
@@ -1,0 +1,24 @@
+package kr.hanjari.backend.domain.tag.domain.repository;
+
+import java.util.Collection;
+import java.util.List;
+import kr.hanjari.backend.domain.tag.domain.entity.ClubTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ClubTagRepository extends JpaRepository<ClubTag, Long> {
+
+    @Query("SELECT ct FROM ClubTag ct JOIN FETCH ct.tag t WHERE ct.club.id IN :clubIds ORDER BY t.priority ASC")
+    List<ClubTag> findByClubIdsWithTagsOrderedByPriority(@Param("clubIds") Collection<Long> clubIds);
+
+    @Query("SELECT ct FROM ClubTag ct JOIN FETCH ct.tag t WHERE ct.club.id = :clubId ORDER BY t.priority ASC")
+    List<ClubTag> findByClubIdWithTagsOrderedByPriority(@Param("clubId") Long clubId);
+
+    boolean existsByClubIdAndTagId(Long clubId, Long tagId);
+
+    @Modifying
+    @Query("DELETE FROM ClubTag ct WHERE ct.club.id = :clubId AND ct.tag.id = :tagId")
+    void deleteByClubIdAndTagId(@Param("clubId") Long clubId, @Param("tagId") Long tagId);
+}

--- a/src/main/java/kr/hanjari/backend/domain/tag/domain/repository/TagRepository.java
+++ b/src/main/java/kr/hanjari/backend/domain/tag/domain/repository/TagRepository.java
@@ -1,0 +1,9 @@
+package kr.hanjari.backend.domain.tag.domain.repository;
+
+import kr.hanjari.backend.domain.tag.domain.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    boolean existsByName(String name);
+}

--- a/src/main/java/kr/hanjari/backend/domain/tag/domain/repository/TagRepository.java
+++ b/src/main/java/kr/hanjari/backend/domain/tag/domain/repository/TagRepository.java
@@ -1,9 +1,12 @@
 package kr.hanjari.backend.domain.tag.domain.repository;
 
+import java.util.List;
 import kr.hanjari.backend.domain.tag.domain.entity.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
     boolean existsByName(String name);
+
+    List<Tag> findAllByOrderByPriorityAsc();
 }

--- a/src/main/java/kr/hanjari/backend/domain/tag/presentation/controller/ClubTagController.java
+++ b/src/main/java/kr/hanjari/backend/domain/tag/presentation/controller/ClubTagController.java
@@ -1,0 +1,45 @@
+package kr.hanjari.backend.domain.tag.presentation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.hanjari.backend.domain.tag.application.command.TagCommandService;
+import kr.hanjari.backend.global.payload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/clubs")
+@RequiredArgsConstructor
+@Tag(name = "Tag", description = "Tag API")
+public class ClubTagController {
+
+    private final TagCommandService tagCommandService;
+
+    @Operation(summary = "[태그] 동아리 태그 추가", description = """
+            ## 동아리에 태그를 추가합니다.
+            ### Path Variables
+            - **clubId**: 태그를 추가할 동아리 ID
+            - **tagId**: 추가할 태그 ID
+            """)
+    @PostMapping("/{clubId}/tags/{tagId}")
+    public ApiResponse<Void> addTagToClub(@PathVariable Long clubId, @PathVariable Long tagId) {
+        tagCommandService.addTagToClub(clubId, tagId);
+        return ApiResponse.onSuccess();
+    }
+
+    @Operation(summary = "[태그] 동아리 태그 삭제", description = """
+            ## 동아리에서 태그를 삭제합니다.
+            ### Path Variables
+            - **clubId**: 태그를 삭제할 동아리 ID
+            - **tagId**: 삭제할 태그 ID
+            """)
+    @DeleteMapping("/{clubId}/tags/{tagId}")
+    public ApiResponse<Void> removeTagFromClub(@PathVariable Long clubId, @PathVariable Long tagId) {
+        tagCommandService.removeTagFromClub(clubId, tagId);
+        return ApiResponse.onSuccess();
+    }
+}

--- a/src/main/java/kr/hanjari/backend/domain/tag/presentation/controller/TagController.java
+++ b/src/main/java/kr/hanjari/backend/domain/tag/presentation/controller/TagController.java
@@ -4,11 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.hanjari.backend.domain.tag.application.command.TagCommandService;
+import kr.hanjari.backend.domain.tag.application.query.TagQueryService;
 import kr.hanjari.backend.domain.tag.presentation.dto.request.CreateTagRequest;
+import kr.hanjari.backend.domain.tag.presentation.dto.response.GetAllTagsResponse;
 import kr.hanjari.backend.domain.tag.presentation.dto.response.TagIdResponse;
 import kr.hanjari.backend.global.payload.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,6 +25,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class TagController {
 
     private final TagCommandService tagCommandService;
+    private final TagQueryService tagQueryService;
+
+    @Operation(summary = "[태그] 전체 태그 목록 조회", description = """
+            ## 동아리에 붙일 수 있는 전체 태그 목록을 우선순위 순으로 조회합니다.
+            """)
+    @GetMapping
+    public ApiResponse<GetAllTagsResponse> getAllTags() {
+        return ApiResponse.onSuccess(tagQueryService.getAllTags());
+    }
 
     @Operation(summary = "[태그] 태그 생성", description = """
             ## 태그를 생성합니다.

--- a/src/main/java/kr/hanjari/backend/domain/tag/presentation/controller/TagController.java
+++ b/src/main/java/kr/hanjari/backend/domain/tag/presentation/controller/TagController.java
@@ -1,0 +1,61 @@
+package kr.hanjari.backend.domain.tag.presentation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.hanjari.backend.domain.tag.application.command.TagCommandService;
+import kr.hanjari.backend.domain.tag.presentation.dto.request.CreateTagRequest;
+import kr.hanjari.backend.domain.tag.presentation.dto.response.TagIdResponse;
+import kr.hanjari.backend.global.payload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/tags")
+@RequiredArgsConstructor
+@Tag(name = "Tag", description = "Tag API")
+public class TagController {
+
+    private final TagCommandService tagCommandService;
+
+    @Operation(summary = "[태그] 태그 생성", description = """
+            ## 태그를 생성합니다.
+            ### Request Body
+            - **name**: 태그명 (예: 저비용, 대회출전, MT, 정기모임, 수시모임, 스터디, 상시모집)
+            - **priority**: 우선순위 (낮을수록 우선 표시)
+            """)
+    @PostMapping
+    public ApiResponse<TagIdResponse> createTag(@RequestBody @Valid CreateTagRequest request) {
+        Long tagId = tagCommandService.createTag(request.name(), request.priority());
+        return ApiResponse.onSuccess(TagIdResponse.of(tagId));
+    }
+
+    @Operation(summary = "[태그] 동아리 태그 추가", description = """
+            ## 동아리에 태그를 추가합니다.
+            ### Path Variables
+            - **clubId**: 태그를 추가할 동아리 ID
+            - **tagId**: 추가할 태그 ID
+            """)
+    @PostMapping("/clubs/{clubId}/{tagId}")
+    public ApiResponse<Void> addTagToClub(@PathVariable Long clubId, @PathVariable Long tagId) {
+        tagCommandService.addTagToClub(clubId, tagId);
+        return ApiResponse.onSuccess();
+    }
+
+    @Operation(summary = "[태그] 동아리 태그 삭제", description = """
+            ## 동아리에서 태그를 삭제합니다.
+            ### Path Variables
+            - **clubId**: 태그를 삭제할 동아리 ID
+            - **tagId**: 삭제할 태그 ID
+            """)
+    @DeleteMapping("/clubs/{clubId}/{tagId}")
+    public ApiResponse<Void> removeTagFromClub(@PathVariable Long clubId, @PathVariable Long tagId) {
+        tagCommandService.removeTagFromClub(clubId, tagId);
+        return ApiResponse.onSuccess();
+    }
+}

--- a/src/main/java/kr/hanjari/backend/domain/tag/presentation/controller/TagController.java
+++ b/src/main/java/kr/hanjari/backend/domain/tag/presentation/controller/TagController.java
@@ -10,9 +10,7 @@ import kr.hanjari.backend.domain.tag.presentation.dto.response.GetAllTagsRespons
 import kr.hanjari.backend.domain.tag.presentation.dto.response.TagIdResponse;
 import kr.hanjari.backend.global.payload.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -45,29 +43,5 @@ public class TagController {
     public ApiResponse<TagIdResponse> createTag(@RequestBody @Valid CreateTagRequest request) {
         Long tagId = tagCommandService.createTag(request.name(), request.priority());
         return ApiResponse.onSuccess(TagIdResponse.of(tagId));
-    }
-
-    @Operation(summary = "[태그] 동아리 태그 추가", description = """
-            ## 동아리에 태그를 추가합니다.
-            ### Path Variables
-            - **clubId**: 태그를 추가할 동아리 ID
-            - **tagId**: 추가할 태그 ID
-            """)
-    @PostMapping("/clubs/{clubId}/{tagId}")
-    public ApiResponse<Void> addTagToClub(@PathVariable Long clubId, @PathVariable Long tagId) {
-        tagCommandService.addTagToClub(clubId, tagId);
-        return ApiResponse.onSuccess();
-    }
-
-    @Operation(summary = "[태그] 동아리 태그 삭제", description = """
-            ## 동아리에서 태그를 삭제합니다.
-            ### Path Variables
-            - **clubId**: 태그를 삭제할 동아리 ID
-            - **tagId**: 삭제할 태그 ID
-            """)
-    @DeleteMapping("/clubs/{clubId}/{tagId}")
-    public ApiResponse<Void> removeTagFromClub(@PathVariable Long clubId, @PathVariable Long tagId) {
-        tagCommandService.removeTagFromClub(clubId, tagId);
-        return ApiResponse.onSuccess();
     }
 }

--- a/src/main/java/kr/hanjari/backend/domain/tag/presentation/dto/request/CreateTagRequest.java
+++ b/src/main/java/kr/hanjari/backend/domain/tag/presentation/dto/request/CreateTagRequest.java
@@ -1,0 +1,17 @@
+package kr.hanjari.backend.domain.tag.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "태그 생성 요청")
+public record CreateTagRequest(
+        @Schema(description = "태그명", example = "저비용")
+        @NotBlank
+        String name,
+
+        @Schema(description = "우선순위 (낮을수록 먼저 표시)", example = "1")
+        @NotNull
+        Integer priority
+) {
+}

--- a/src/main/java/kr/hanjari/backend/domain/tag/presentation/dto/response/GetAllTagsResponse.java
+++ b/src/main/java/kr/hanjari/backend/domain/tag/presentation/dto/response/GetAllTagsResponse.java
@@ -1,0 +1,29 @@
+package kr.hanjari.backend.domain.tag.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import kr.hanjari.backend.domain.tag.domain.entity.Tag;
+
+@Schema(description = "전체 태그 목록 응답")
+public record GetAllTagsResponse(
+        @Schema(description = "태그 목록 (우선순위 순)")
+        List<TagResponse> tags
+) {
+    public static GetAllTagsResponse of(List<Tag> tags) {
+        return new GetAllTagsResponse(
+                tags.stream().map(TagResponse::from).toList()
+        );
+    }
+
+    @Schema(description = "태그")
+    public record TagResponse(
+            @Schema(description = "태그 ID", example = "1")
+            Long id,
+            @Schema(description = "태그명", example = "저비용")
+            String name
+    ) {
+        public static TagResponse from(Tag tag) {
+            return new TagResponse(tag.getId(), tag.getName());
+        }
+    }
+}

--- a/src/main/java/kr/hanjari/backend/domain/tag/presentation/dto/response/TagIdResponse.java
+++ b/src/main/java/kr/hanjari/backend/domain/tag/presentation/dto/response/TagIdResponse.java
@@ -1,0 +1,13 @@
+package kr.hanjari.backend.domain.tag.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "생성된 태그 ID 응답")
+public record TagIdResponse(
+        @Schema(description = "태그 ID", example = "1")
+        Long tagId
+) {
+    public static TagIdResponse of(Long tagId) {
+        return new TagIdResponse(tagId);
+    }
+}

--- a/src/main/java/kr/hanjari/backend/global/payload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/hanjari/backend/global/payload/code/status/ErrorStatus.java
@@ -69,7 +69,13 @@ public enum ErrorStatus implements BaseErrorCode {
 
     _SERVICE_ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "SERVICE_ANNOUNCEMENT404", "공지사항을 찾을 수 없습니다."),
 
-    _FAQ_NOT_FOUND(HttpStatus.NOT_FOUND, "FAQ404", "FAQ를 찾을 수 없습니다.")
+    _FAQ_NOT_FOUND(HttpStatus.NOT_FOUND, "FAQ404", "FAQ를 찾을 수 없습니다."),
+
+    // 태그 관련
+    _TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "TAG404", "태그를 찾을 수 없습니다."),
+    _TAG_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "TAG400", "이미 존재하는 태그명입니다."),
+    _TAG_ALREADY_ASSIGNED(HttpStatus.BAD_REQUEST, "TAG400", "이미 동아리에 추가된 태그입니다."),
+    _TAG_NOT_ASSIGNED(HttpStatus.NOT_FOUND, "TAG404", "동아리에 등록되지 않은 태그입니다.")
 
     ;
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## Changes
- `Tag`, `ClubTag` 엔티티 및 repository 추가
- 태그 생성 API: `POST /api/tags`
- 전체 태그 목록 조회 API: `GET /api/tags` (우선순위 순)
- 동아리 태그 추가/삭제 API: `POST/DELETE /api/clubs/{clubId}/tags/{tagId}`
- 동아리 검색 필터를 `RecruitmentStatus` → `tagId` 기반으로 변경
- 모든 동아리 응답 DTO에서 `recruitmentStatus` → `tags(List<String>)` 로 교체 (최대 2개, 우선순위 순)
- `ActivityController`, `DocumentController`, `AnnouncementController` deprecated 처리
- 목록 API는 IN절 배치 조회로 N+1 방지, 단건 API는 단일 쿼리
- QueryDSL EXISTS 서브쿼리로 태그 필터링

- CLAUDE.md 수정
## Related Issue
Closes #188

## Check List
- [x] Local Test